### PR TITLE
Fix requestMagicLink comment

### DIFF
--- a/Backend/handlers/auth.go
+++ b/Backend/handlers/auth.go
@@ -48,7 +48,7 @@ func registerAuthRoutes(mux *http.ServeMux) {
 	})))
 }
 
-// endpoint: GET /api/v1/auth/requestMagicLink
+// endpoint: POST /api/v1/auth/requestMagicLink
 func handleRequestMagicLink(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Email string `json:"email"`


### PR DESCRIPTION
## Summary
- fix the `handleRequestMagicLink` comment to document the correct HTTP verb

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685fb42194ec8328b5bd278eade98c93