### PR TITLE
Remove built binary from Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 # Backend binary
 Backend/clubs
+Backend/main
 
 # Logs
 logs


### PR DESCRIPTION
## Summary
- delete the old `Backend/main` executable
- add `Backend/main` to `.gitignore`

## Testing
- `go test ./...` in `Backend`
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe31415c4832895cbc4be1a66bf7a