### PR TITLE
Fix IsMember empty ID handling

### DIFF
--- a/Backend/models/members.go
+++ b/Backend/models/members.go
@@ -43,9 +43,11 @@ func (c *Club) IsAdmin(user User) bool {
 	return false
 }
 
+// IsMember reports whether the provided user belongs to the club. If the
+// user has an empty ID the function simply returns false.
 func (c *Club) IsMember(user User) bool {
 	if user.ID == "" {
-		log.Fatal("User ID is empty")
+		log.Default().Println("IsMember called with empty user ID")
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- avoid fatal exit when checking club membership for a user with no ID

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685fe320f9908328bda27bd5839bf103