### PR TITLE
Hash refresh tokens

### DIFF
--- a/Backend/auth/auth.go
+++ b/Backend/auth/auth.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -154,8 +156,11 @@ func ValidateRefreshToken(tokenStr string) (string, error) {
 		return "", fmt.Errorf("invalid user ID")
 	}
 
+	sum := sha256.Sum256([]byte(token.Raw))
+	tokenHash := hex.EncodeToString(sum[:])
+
 	var expiresAt time.Time
-	err = database.Db.Raw(`SELECT expires_at FROM refresh_tokens WHERE user_id = ? AND token = ?`, userID, token.Raw).Scan(&expiresAt).Error
+	err = database.Db.Raw(`SELECT expires_at FROM refresh_tokens WHERE user_id = ? AND token = ?`, userID, tokenHash).Scan(&expiresAt).Error
 	if err != nil {
 		return "", err
 	}

--- a/Backend/handlers/user.go
+++ b/Backend/handlers/user.go
@@ -230,7 +230,7 @@ func handleGetMySessions(w http.ResponseWriter, r *http.Request) {
 			UserAgent: session.UserAgent,
 			IPAddress: session.IPAddress,
 			CreatedAt: session.CreatedAt,
-			IsCurrent: session.Token == currentToken,
+			IsCurrent: session.Token == models.HashToken(currentToken),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- hash refresh tokens using SHA-256
- compare hashed tokens when validating or listing sessions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687b872219848328b52c4d0a88dae21b