### PR TITLE
feat: Implement team management functionality in backend and frontend

### DIFF
--- a/Backend/handlers/api.go
+++ b/Backend/handlers/api.go
@@ -16,6 +16,7 @@ func Handler_v1() http.Handler {
 	registerClubRoutes(mux)
 	registerClubSettingsRoutes(mux)
 	registerMemberRoutes(mux)
+	registerTeamRoutes(mux)
 	registerShiftRoutes(mux)
 	registerEventRoutes(mux)
 	registerNewsRoutes(mux)

--- a/Backend/handlers/teams.go
+++ b/Backend/handlers/teams.go
@@ -1,0 +1,681 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/NLstn/clubs/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func registerTeamRoutes(mux *http.ServeMux) {
+	// GET /api/v1/clubs/{clubid}/teams
+	mux.Handle("/api/v1/clubs/{clubid}/teams", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		// Check if this is a request for user teams via query param
+		if userID := r.URL.Query().Get("user"); userID != "" {
+			// Handle get user teams
+			handleGetUserTeams(w, r)
+			return
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			handleGetClubTeams(w, r)
+		case http.MethodPost:
+			handleCreateTeam(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	// GET/PUT/DELETE /api/v1/clubs/{clubid}/teams/{teamid}
+	mux.Handle("/api/v1/clubs/{clubid}/teams/{teamid}", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleGetTeam(w, r)
+		case http.MethodPut:
+			handleUpdateTeam(w, r)
+		case http.MethodDelete:
+			handleDeleteTeam(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	// GET/POST /api/v1/clubs/{clubid}/teams/{teamid}/members
+	mux.Handle("/api/v1/clubs/{clubid}/teams/{teamid}/members", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleGetTeamMembers(w, r)
+		case http.MethodPost:
+			handleAddTeamMember(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	// PATCH/DELETE /api/v1/clubs/{clubid}/teams/{teamid}/members/{memberid}
+	mux.Handle("/api/v1/clubs/{clubid}/teams/{teamid}/members/{memberid}", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			handleUpdateTeamMemberRole(w, r)
+		case http.MethodDelete:
+			handleRemoveTeamMember(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+}
+
+// endpoint: GET /api/v1/clubs/{clubid}/teams
+func handleGetClubTeams(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if user is a member of the club
+	if !club.IsMember(user) {
+		http.Error(w, "User is not a member of this club", http.StatusForbidden)
+		return
+	}
+
+	teams, err := club.GetTeams()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(teams)
+}
+
+// endpoint: POST /api/v1/clubs/{clubid}/teams
+func handleCreateTeam(w http.ResponseWriter, r *http.Request) {
+	type CreateTeamRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var payload CreateTeamRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Name == "" {
+		http.Error(w, "Team name is required", http.StatusBadRequest)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if user can create teams (only club admins)
+	if !club.CanUserCreateTeam(user) {
+		http.Error(w, "Only club admins can create teams", http.StatusForbidden)
+		return
+	}
+
+	team, err := club.CreateTeam(payload.Name, payload.Description, user.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(team)
+}
+
+// endpoint: GET /api/v1/clubs/{clubid}/teams/{teamid}
+func handleGetTeam(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if user is a member of the club
+	if !club.IsMember(user) {
+		http.Error(w, "User is not a member of this club", http.StatusForbidden)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(team)
+}
+
+// endpoint: PUT /api/v1/clubs/{clubid}/teams/{teamid}
+func handleUpdateTeam(w http.ResponseWriter, r *http.Request) {
+	type UpdateTeamRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var payload UpdateTeamRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Name == "" {
+		http.Error(w, "Team name is required", http.StatusBadRequest)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	// Check if user can edit the team
+	if !team.CanUserEditTeam(user) {
+		http.Error(w, "Insufficient permissions to edit this team", http.StatusForbidden)
+		return
+	}
+
+	err = team.Update(payload.Name, payload.Description, user.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// endpoint: DELETE /api/v1/clubs/{clubid}/teams/{teamid}
+func handleDeleteTeam(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	// Check if user can delete the team
+	if !team.CanUserDeleteTeam(user) {
+		http.Error(w, "Insufficient permissions to delete this team", http.StatusForbidden)
+		return
+	}
+
+	err = team.SoftDelete(user.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// endpoint: GET /api/v1/clubs/{clubid}/teams/{teamid}/members
+func handleGetTeamMembers(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if user is a member of the club
+	if !club.IsMember(user) {
+		http.Error(w, "User is not a member of this club", http.StatusForbidden)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	members, err := team.GetTeamMembersWithUserInfo()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(members)
+}
+
+// endpoint: POST /api/v1/clubs/{clubid}/teams/{teamid}/members
+func handleAddTeamMember(w http.ResponseWriter, r *http.Request) {
+	type AddMemberRequest struct {
+		UserID string `json:"userId"`
+		Role   string `json:"role"`
+	}
+
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var payload AddMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if _, err := uuid.Parse(payload.UserID); err != nil {
+		http.Error(w, "Invalid user ID format", http.StatusBadRequest)
+		return
+	}
+
+	// Default role to member if not specified
+	if payload.Role == "" {
+		payload.Role = "member"
+	}
+
+	// Validate role
+	if payload.Role != "admin" && payload.Role != "member" {
+		http.Error(w, "Invalid role. Must be 'admin' or 'member'", http.StatusBadRequest)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	// Check if user can edit the team
+	if !team.CanUserEditTeam(user) {
+		http.Error(w, "Insufficient permissions to manage team members", http.StatusForbidden)
+		return
+	}
+
+	// Check if the user being added is a member of the club
+	targetUser, err := models.GetUserByID(payload.UserID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if !club.IsMember(targetUser) {
+		http.Error(w, "User is not a member of the club", http.StatusBadRequest)
+		return
+	}
+
+	// Check if user is already a member of the team
+	if team.IsMember(targetUser) {
+		http.Error(w, "User is already a member of this team", http.StatusBadRequest)
+		return
+	}
+
+	err = team.AddMember(payload.UserID, payload.Role, user.ID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte(`{"message": "Member added to team successfully"}`))
+}
+
+// endpoint: PATCH /api/v1/clubs/{clubid}/teams/{teamid}/members/{memberid}
+func handleUpdateTeamMemberRole(w http.ResponseWriter, r *http.Request) {
+	type UpdateRoleRequest struct {
+		Role string `json:"role"`
+	}
+
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	memberID := extractPathParam(r, "members")
+	if _, err := uuid.Parse(memberID); err != nil {
+		http.Error(w, "Invalid member ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var payload UpdateRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Role != "admin" && payload.Role != "member" {
+		http.Error(w, "Invalid role. Must be 'admin' or 'member'", http.StatusBadRequest)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	err = team.UpdateMemberRole(user, memberID, payload.Role)
+	if err != nil {
+		if err == models.ErrNotTeamAdmin {
+			http.Error(w, "Insufficient permissions to change member roles", http.StatusForbidden)
+			return
+		}
+		if err == models.ErrLastTeamAdminDemotion {
+			http.Error(w, "Cannot demote the last admin of the team", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// endpoint: DELETE /api/v1/clubs/{clubid}/teams/{teamid}/members/{memberid}
+func handleRemoveTeamMember(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	teamID := extractPathParam(r, "teams")
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return
+	}
+
+	memberID := extractPathParam(r, "members")
+	if _, err := uuid.Parse(memberID); err != nil {
+		http.Error(w, "Invalid member ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Verify team belongs to the club
+	if team.ClubID != clubID {
+		http.Error(w, "Team does not belong to this club", http.StatusBadRequest)
+		return
+	}
+
+	// Check if user can edit the team
+	if !team.CanUserEditTeam(user) {
+		http.Error(w, "Insufficient permissions to remove team members", http.StatusForbidden)
+		return
+	}
+
+	err = team.RemoveMember(memberID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// endpoint: GET /api/v1/clubs/{clubid}/teams/user/{userid}
+func handleGetUserTeams(w http.ResponseWriter, r *http.Request) {
+	clubID := extractPathParam(r, "clubs")
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return
+	}
+
+	userIDParam := r.URL.Query().Get("user")
+	if userIDParam == "" {
+		http.Error(w, "User ID query parameter is required", http.StatusBadRequest)
+		return
+	}
+	if _, err := uuid.Parse(userIDParam); err != nil {
+		http.Error(w, "Invalid user ID format", http.StatusBadRequest)
+		return
+	}
+
+	user := extractUser(r)
+	if user.ID == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if user is a member of the club
+	if !club.IsMember(user) {
+		http.Error(w, "User is not a member of this club", http.StatusForbidden)
+		return
+	}
+
+	teams, err := models.GetUserTeams(userIDParam, clubID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(teams)
+}

--- a/Backend/handlers/teams_test.go
+++ b/Backend/handlers/teams_test.go
@@ -1,0 +1,306 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/NLstn/clubs/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamEndpoints(t *testing.T) {
+	// Setup test database
+	SetupTestDB(t)
+	defer TeardownTestDB(t)
+	MockEnvironmentVariables(t)
+
+	handler := GetTestHandler()
+
+	t.Run("Get Club Teams - Unauthorized", func(t *testing.T) {
+		user, _ := CreateTestUser(t, "teamtest@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		req := MakeRequest(t, "GET", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), nil, "")
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("Get Club Teams - Authorized Member", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest2@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		req := MakeRequest(t, "GET", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), nil, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusOK, rr.Code)
+
+		var teams []map[string]interface{}
+		ParseJSONResponse(t, rr, &teams)
+		assert.Len(t, teams, 0) // No teams initially
+	})
+
+	t.Run("Create Team - Unauthorized", func(t *testing.T) {
+		user, _ := CreateTestUser(t, "teamtest3@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		teamData := map[string]string{
+			"name":        "Development Team",
+			"description": "Team for development tasks",
+		}
+
+		req := MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), teamData, "")
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("Create Team - Club Admin", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest4@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		teamData := map[string]string{
+			"name":        "Development Team",
+			"description": "Team for development tasks",
+		}
+
+		req := MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), teamData, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusCreated, rr.Code)
+
+		var team map[string]interface{}
+		ParseJSONResponse(t, rr, &team)
+		assert.Equal(t, "Development Team", team["name"])
+		assert.Equal(t, "Team for development tasks", team["description"])
+		assert.Equal(t, club.ID, team["clubId"])
+	})
+
+	t.Run("Create Team - Regular Member Cannot Create", func(t *testing.T) {
+		admin, _ := CreateTestUser(t, "teamadmin@example.com")
+		club := CreateTestClub(t, admin, "Test Club")
+
+		member, memberToken := CreateTestUser(t, "teammember@example.com")
+		// Add member to club as regular member
+		err := club.AddMember(member.ID, "member")
+		assert.NoError(t, err)
+
+		teamData := map[string]string{
+			"name":        "Member Team",
+			"description": "Team created by member",
+		}
+
+		req := MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), teamData, memberToken)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("Create Team - Invalid Data", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest5@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		// Test with empty name
+		teamData := map[string]string{
+			"name":        "",
+			"description": "Team with no name",
+		}
+
+		req := MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams", club.ID), teamData, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("Get Team Details", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest6@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		// Create a team first
+		team, err := club.CreateTeam("Test Team", "A test team", user.ID)
+		assert.NoError(t, err)
+
+		req := MakeRequest(t, "GET", fmt.Sprintf("/api/v1/clubs/%s/teams/%s", club.ID, team.ID), nil, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusOK, rr.Code)
+
+		var responseTeam map[string]interface{}
+		ParseJSONResponse(t, rr, &responseTeam)
+		assert.Equal(t, "Test Team", responseTeam["name"])
+		assert.Equal(t, "A test team", responseTeam["description"])
+	})
+
+	t.Run("Update Team", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest7@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		// Create a team first
+		team, err := club.CreateTeam("Original Team", "Original description", user.ID)
+		assert.NoError(t, err)
+
+		updateData := map[string]string{
+			"name":        "Updated Team",
+			"description": "Updated description",
+		}
+
+		req := MakeRequest(t, "PUT", fmt.Sprintf("/api/v1/clubs/%s/teams/%s", club.ID, team.ID), updateData, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusNoContent, rr.Code)
+
+		// Verify the update
+		updatedTeam, err := models.GetTeamByID(team.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, "Updated Team", updatedTeam.Name)
+		assert.Equal(t, "Updated description", updatedTeam.Description)
+	})
+
+	t.Run("Delete Team", func(t *testing.T) {
+		user, token := CreateTestUser(t, "teamtest8@example.com")
+		club := CreateTestClub(t, user, "Test Club")
+
+		// Create a team first
+		team, err := club.CreateTeam("Team to Delete", "This team will be deleted", user.ID)
+		assert.NoError(t, err)
+
+		req := MakeRequest(t, "DELETE", fmt.Sprintf("/api/v1/clubs/%s/teams/%s", club.ID, team.ID), nil, token)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusNoContent, rr.Code)
+
+		// Verify the team is soft deleted
+		_, err = models.GetTeamByID(team.ID)
+		assert.Error(t, err) // Should not be found since GetTeamByID only returns non-deleted teams
+	})
+
+	t.Run("Team Members Management", func(t *testing.T) {
+		admin, adminToken := CreateTestUser(t, "teamadmin2@example.com")
+		club := CreateTestClub(t, admin, "Test Club")
+
+		member1, _ := CreateTestUser(t, "teammember1@example.com")
+		member2, _ := CreateTestUser(t, "teammember2@example.com")
+
+		// Add members to club
+		err := club.AddMember(member1.ID, "member")
+		assert.NoError(t, err)
+		err = club.AddMember(member2.ID, "member")
+		assert.NoError(t, err)
+
+		// Create a team
+		team, err := club.CreateTeam("Test Team", "Team for member testing", admin.ID)
+		assert.NoError(t, err)
+
+		// Test getting team members (should be empty initially)
+		req := MakeRequest(t, "GET", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members", club.ID, team.ID), nil, adminToken)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusOK, rr.Code)
+
+		var members []map[string]interface{}
+		ParseJSONResponse(t, rr, &members)
+		assert.Len(t, members, 0)
+
+		// Add member1 to team as member
+		addMemberData := map[string]string{
+			"userId": member1.ID,
+			"role":   "member",
+		}
+
+		req = MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members", club.ID, team.ID), addMemberData, adminToken)
+		rr = ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusCreated, rr.Code)
+
+		// Add member2 to team as admin
+		addAdminData := map[string]string{
+			"userId": member2.ID,
+			"role":   "admin",
+		}
+
+		req = MakeRequest(t, "POST", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members", club.ID, team.ID), addAdminData, adminToken)
+		rr = ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusCreated, rr.Code)
+
+		// Verify team members
+		req = MakeRequest(t, "GET", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members", club.ID, team.ID), nil, adminToken)
+		rr = ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusOK, rr.Code)
+
+		ParseJSONResponse(t, rr, &members)
+		assert.Len(t, members, 2)
+
+		// Find the members in the response
+		var memberRole, adminRole string
+		for _, member := range members {
+			if member["userId"].(string) == member1.ID {
+				memberRole = member["role"].(string)
+			}
+			if member["userId"].(string) == member2.ID {
+				adminRole = member["role"].(string)
+			}
+		}
+		assert.Equal(t, "member", memberRole)
+		assert.Equal(t, "admin", adminRole)
+	})
+
+	t.Run("Team Member Role Update", func(t *testing.T) {
+		admin, adminToken := CreateTestUser(t, "teamadmin3@example.com")
+		club := CreateTestClub(t, admin, "Test Club")
+
+		member, _ := CreateTestUser(t, "teammember3@example.com")
+		err := club.AddMember(member.ID, "member")
+		assert.NoError(t, err)
+
+		// Create team and add member
+		team, err := club.CreateTeam("Role Test Team", "Team for role testing", admin.ID)
+		assert.NoError(t, err)
+
+		err = team.AddMember(member.ID, "member", admin.ID)
+		assert.NoError(t, err)
+
+		// Get the team member record
+		teamMembers, err := team.GetTeamMembersWithUserInfo()
+		assert.NoError(t, err)
+		assert.Len(t, teamMembers, 1)
+
+		memberID := teamMembers[0]["id"].(string)
+
+		// Promote member to admin
+		updateRoleData := map[string]string{
+			"role": "admin",
+		}
+
+		req := MakeRequest(t, "PATCH", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members/%s", club.ID, team.ID, memberID), updateRoleData, adminToken)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusNoContent, rr.Code)
+
+		// Verify role change
+		updatedMembers, err := team.GetTeamMembersWithUserInfo()
+		assert.NoError(t, err)
+		assert.Equal(t, "admin", updatedMembers[0]["role"].(string))
+	})
+
+	t.Run("Remove Team Member", func(t *testing.T) {
+		admin, adminToken := CreateTestUser(t, "teamadmin4@example.com")
+		club := CreateTestClub(t, admin, "Test Club")
+
+		member, _ := CreateTestUser(t, "teammember4@example.com")
+		err := club.AddMember(member.ID, "member")
+		assert.NoError(t, err)
+
+		// Create team and add member
+		team, err := club.CreateTeam("Remove Test Team", "Team for removal testing", admin.ID)
+		assert.NoError(t, err)
+
+		err = team.AddMember(member.ID, "member", admin.ID)
+		assert.NoError(t, err)
+
+		// Get the team member record
+		teamMembers, err := team.GetTeamMembersWithUserInfo()
+		assert.NoError(t, err)
+		assert.Len(t, teamMembers, 1)
+
+		memberID := teamMembers[0]["id"].(string)
+
+		// Remove member from team
+		req := MakeRequest(t, "DELETE", fmt.Sprintf("/api/v1/clubs/%s/teams/%s/members/%s", club.ID, team.ID, memberID), nil, adminToken)
+		rr := ExecuteRequest(t, handler, req)
+		CheckResponseCode(t, http.StatusNoContent, rr.Code)
+
+		// Verify member is removed
+		updatedMembers, err := team.GetTeamMembersWithUserInfo()
+		assert.NoError(t, err)
+		assert.Len(t, updatedMembers, 0)
+	})
+}

--- a/Backend/main.go
+++ b/Backend/main.go
@@ -26,6 +26,8 @@ func main() {
 	//        in a circular dependency.
 	err = database.Db.AutoMigrate(&models.Club{},
 		&models.Member{},
+		&models.Team{},
+		&models.TeamMember{},
 		&models.MagicLink{},
 		&models.User{},
 		&models.JoinRequest{},

--- a/Backend/models/teams.go
+++ b/Backend/models/teams.go
@@ -1,0 +1,357 @@
+package models
+
+import (
+	"errors"
+	"time"
+
+	"github.com/NLstn/clubs/database"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var ErrNotTeamAdmin = errors.New("user is not a team admin")
+var ErrNotClubAdminOrTeamAdmin = errors.New("user is not a club admin or team admin")
+var ErrLastTeamAdminDemotion = errors.New("cannot demote the last admin of the team")
+
+type Team struct {
+	ID          string     `json:"id" gorm:"type:uuid;primary_key"`
+	ClubID      string     `json:"clubId" gorm:"type:uuid;not null"`
+	Name        string     `json:"name" gorm:"not null"`
+	Description string     `json:"description"`
+	CreatedAt   time.Time  `json:"createdAt"`
+	CreatedBy   string     `json:"createdBy" gorm:"type:uuid"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+	UpdatedBy   string     `json:"updatedBy" gorm:"type:uuid"`
+	Deleted     bool       `json:"deleted" gorm:"default:false"`
+	DeletedAt   *time.Time `json:"deletedAt,omitempty"`
+	DeletedBy   *string    `json:"deletedBy,omitempty" gorm:"type:uuid"`
+}
+
+type TeamMember struct {
+	ID        string    `json:"id" gorm:"type:uuid;primary_key"`
+	TeamID    string    `json:"teamId" gorm:"type:uuid;not null"`
+	UserID    string    `json:"userId" gorm:"type:uuid;not null"`
+	Role      string    `json:"role" gorm:"default:member"` // admin, member
+	CreatedAt time.Time `json:"createdAt"`
+	CreatedBy string    `json:"createdBy" gorm:"type:uuid"`
+	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedBy string    `json:"updatedBy" gorm:"type:uuid"`
+}
+
+// BeforeCreate generates UUID for new team
+func (t *Team) BeforeCreate(tx *gorm.DB) (err error) {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	return
+}
+
+// BeforeCreate generates UUID for new team member
+func (tm *TeamMember) BeforeCreate(tx *gorm.DB) (err error) {
+	if tm.ID == "" {
+		tm.ID = uuid.New().String()
+	}
+	return
+}
+
+// CreateTeam creates a new team within a club
+func (c *Club) CreateTeam(name, description, createdByUserID string) (Team, error) {
+	team := Team{
+		ClubID:      c.ID,
+		Name:        name,
+		Description: description,
+		CreatedBy:   createdByUserID,
+		UpdatedBy:   createdByUserID,
+	}
+
+	err := database.Db.Create(&team).Error
+	if err != nil {
+		return Team{}, err
+	}
+
+	return team, nil
+}
+
+// GetTeams returns all teams for a club
+func (c *Club) GetTeams() ([]Team, error) {
+	var teams []Team
+	err := database.Db.Where("club_id = ? AND deleted = false", c.ID).Find(&teams).Error
+	return teams, err
+}
+
+// GetTeamByID returns a team by ID
+func GetTeamByID(teamID string) (Team, error) {
+	var team Team
+	err := database.Db.Where("id = ? AND deleted = false", teamID).First(&team).Error
+	return team, err
+}
+
+// Update updates team information
+func (t *Team) Update(name, description, updatedBy string) error {
+	return database.Db.Model(t).Updates(map[string]interface{}{
+		"name":        name,
+		"description": description,
+		"updated_by":  updatedBy,
+		"updated_at":  time.Now(),
+	}).Error
+}
+
+// SoftDelete soft deletes a team
+func (t *Team) SoftDelete(deletedBy string) error {
+	now := time.Now()
+	return database.Db.Model(t).Updates(map[string]interface{}{
+		"deleted":    true,
+		"deleted_at": &now,
+		"deleted_by": &deletedBy,
+		"updated_at": now,
+	}).Error
+}
+
+// AddMember adds a user to the team
+func (t *Team) AddMember(userID, role, addedBy string) error {
+	teamMember := TeamMember{
+		TeamID:    t.ID,
+		UserID:    userID,
+		Role:      role,
+		CreatedBy: addedBy,
+		UpdatedBy: addedBy,
+	}
+
+	return database.Db.Create(&teamMember).Error
+}
+
+// GetMembers returns all members of the team
+func (t *Team) GetMembers() ([]TeamMember, error) {
+	var members []TeamMember
+	err := database.Db.Where("team_id = ?", t.ID).Find(&members).Error
+	return members, err
+}
+
+// GetTeamMembersWithUserInfo returns team members with user information
+func (t *Team) GetTeamMembersWithUserInfo() ([]map[string]interface{}, error) {
+	var results []map[string]interface{}
+
+	query := `
+		SELECT 
+			tm.id,
+			tm.user_id,
+			tm.role,
+			tm.created_at as joined_at,
+			CONCAT(u.first_name, ' ', u.last_name) as name
+		FROM team_members tm
+		JOIN users u ON tm.user_id = u.id
+		WHERE tm.team_id = ?
+		ORDER BY 
+			CASE tm.role 
+				WHEN 'admin' THEN 1 
+				WHEN 'member' THEN 2 
+				ELSE 3 
+			END,
+			CONCAT(u.first_name, ' ', u.last_name)
+	`
+
+	rows, err := database.Db.Raw(query, t.ID).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var memberInfo struct {
+			ID       string    `json:"id"`
+			UserID   string    `json:"userId"`
+			Role     string    `json:"role"`
+			JoinedAt time.Time `json:"joinedAt"`
+			Name     string    `json:"name"`
+		}
+
+		err := database.Db.ScanRows(rows, &memberInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, map[string]interface{}{
+			"id":       memberInfo.ID,
+			"userId":   memberInfo.UserID,
+			"role":     memberInfo.Role,
+			"joinedAt": memberInfo.JoinedAt.Format("2006-01-02T15:04:05Z"),
+			"name":     memberInfo.Name,
+		})
+	}
+
+	return results, nil
+}
+
+// RemoveMember removes a user from the team
+func (t *Team) RemoveMember(memberID string) error {
+	return database.Db.Where("id = ? AND team_id = ?", memberID, t.ID).Delete(&TeamMember{}).Error
+}
+
+// UpdateMemberRole updates a team member's role
+func (t *Team) UpdateMemberRole(changingUser User, memberID, newRole string) error {
+	var teamMember TeamMember
+	err := database.Db.Where("id = ? AND team_id = ?", memberID, t.ID).First(&teamMember).Error
+	if err != nil {
+		return err
+	}
+
+	// Validate role
+	if newRole != "admin" && newRole != "member" {
+		return errors.New("invalid role")
+	}
+
+	// Check permissions
+	canChange, err := t.canChangeRole(changingUser, teamMember, newRole)
+	if err != nil {
+		return err
+	}
+	if !canChange {
+		return ErrNotTeamAdmin
+	}
+
+	// Update role
+	teamMember.Role = newRole
+	teamMember.UpdatedBy = changingUser.ID
+	teamMember.UpdatedAt = time.Now()
+
+	return database.Db.Save(&teamMember).Error
+}
+
+// canChangeRole checks if a user can change another member's role
+func (t *Team) canChangeRole(changingUser User, targetMember TeamMember, newRole string) (bool, error) {
+	// Get the club this team belongs to
+	var club Club
+	err := database.Db.Where("id = ?", t.ClubID).First(&club).Error
+	if err != nil {
+		return false, err
+	}
+
+	// Club owners can change any role
+	if club.IsOwner(changingUser) {
+		// Check if this would demote the last team admin
+		if targetMember.Role == "admin" && newRole != "admin" {
+			adminCount, err := t.CountAdmins()
+			if err != nil {
+				return false, err
+			}
+			if adminCount <= 1 {
+				return false, ErrLastTeamAdminDemotion
+			}
+		}
+		return true, nil
+	}
+
+	// Club admins can change any role
+	if club.IsAdmin(changingUser) {
+		// Check if this would demote the last team admin
+		if targetMember.Role == "admin" && newRole != "admin" {
+			adminCount, err := t.CountAdmins()
+			if err != nil {
+				return false, err
+			}
+			if adminCount <= 1 {
+				return false, ErrLastTeamAdminDemotion
+			}
+		}
+		return true, nil
+	}
+
+	// Team admins can promote members to admin or demote admins to member
+	if t.IsAdmin(changingUser) {
+		// Check if this would demote the last team admin (including themselves)
+		if targetMember.Role == "admin" && newRole != "admin" {
+			adminCount, err := t.CountAdmins()
+			if err != nil {
+				return false, err
+			}
+			if adminCount <= 1 {
+				return false, ErrLastTeamAdminDemotion
+			}
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// IsAdmin checks if a user is an admin of the team
+func (t *Team) IsAdmin(user User) bool {
+	var count int64
+	database.Db.Model(&TeamMember{}).Where("team_id = ? AND user_id = ? AND role = ?", t.ID, user.ID, "admin").Count(&count)
+	return count > 0
+}
+
+// IsMember checks if a user is a member of the team
+func (t *Team) IsMember(user User) bool {
+	var count int64
+	database.Db.Model(&TeamMember{}).Where("team_id = ? AND user_id = ?", t.ID, user.ID).Count(&count)
+	return count > 0
+}
+
+// CountAdmins returns the number of admins in the team
+func (t *Team) CountAdmins() (int64, error) {
+	var count int64
+	err := database.Db.Model(&TeamMember{}).Where("team_id = ? AND role = ?", t.ID, "admin").Count(&count).Error
+	return count, err
+}
+
+// GetUserRole returns the role of a user in the team
+func (t *Team) GetUserRole(user User) (string, error) {
+	var teamMember TeamMember
+	err := database.Db.Where("team_id = ? AND user_id = ?", t.ID, user.ID).First(&teamMember).Error
+	if err != nil {
+		return "", err
+	}
+	return teamMember.Role, nil
+}
+
+// GetUserTeams returns all teams a user belongs to within a specific club
+func GetUserTeams(userID, clubID string) ([]Team, error) {
+	var teams []Team
+
+	query := `
+		SELECT DISTINCT t.* 
+		FROM teams t
+		JOIN team_members tm ON t.id = tm.team_id
+		WHERE tm.user_id = ? AND t.club_id = ? AND t.deleted = false
+	`
+
+	err := database.Db.Raw(query, userID, clubID).Find(&teams).Error
+	return teams, err
+}
+
+// CanUserCreateTeam checks if a user can create teams in a club
+func (c *Club) CanUserCreateTeam(user User) bool {
+	return c.IsAdmin(user) // Only club admins can create teams
+}
+
+// CanUserEditTeam checks if a user can edit a team
+func (t *Team) CanUserEditTeam(user User) bool {
+	// Get the club this team belongs to
+	var club Club
+	err := database.Db.Where("id = ?", t.ClubID).First(&club).Error
+	if err != nil {
+		return false
+	}
+
+	// Club owners/admins can edit any team
+	if club.IsAdmin(user) {
+		return true
+	}
+
+	// Team admins can edit their team
+	return t.IsAdmin(user)
+}
+
+// CanUserDeleteTeam checks if a user can delete a team
+func (t *Team) CanUserDeleteTeam(user User) bool {
+	// Get the club this team belongs to
+	var club Club
+	err := database.Db.Where("id = ?", t.ClubID).First(&club).Error
+	if err != nil {
+		return false
+	}
+
+	// Only club owners/admins can delete teams
+	return club.IsAdmin(user)
+}

--- a/Frontend/src/i18n/locales/de.json
+++ b/Frontend/src/i18n/locales/de.json
@@ -7,6 +7,7 @@
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "add": "Hinzufügen",
+    "remove": "Entfernen",
     "create": "Erstellen",
     "update": "Aktualisieren",
     "submit": "Senden",
@@ -20,6 +21,8 @@
     "search": "Suchen",
     "filter": "Filter",
     "sort": "Sortieren",
+    "name": "Name",
+    "role": "Rolle",
     "actions": "Aktionen"
   },
   "navigation": {
@@ -65,6 +68,7 @@
     "latestNews": "Aktuelle Nachrichten",
     "overview": "Übersicht",
     "members": "Mitglieder",
+    "teams": "Teams",
     "roles": {
       "owner": "Besitzer",
       "admin": "Administrator",
@@ -88,6 +92,29 @@
       "failedToLoadSettings": "Vereinseinstellungen konnten nicht geladen werden",
       "failedToUpdateSettings": "Einstellungen konnten nicht aktualisiert werden",
       "loadingNews": "Fehler beim Laden der Nachrichten: {{error}}"
+    }
+  },
+  "teams": {
+    "title": "Teams",
+    "createTeam": "Team erstellen",
+    "editTeam": "Team bearbeiten",
+    "teamName": "Team-Name",
+    "teamNamePlaceholder": "Team-Name eingeben",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Team-Beschreibung eingeben",
+    "deleteConfirmation": "Sind Sie sicher, dass Sie dieses Team löschen möchten?",
+    "membersOf": "Mitglieder von {{teamName}}",
+    "addMember": "Mitglied hinzufügen",
+    "removeMemberConfirmation": "Sind Sie sicher, dass Sie dieses Mitglied aus dem Team entfernen möchten?",
+    "joinedAt": "Beigetreten",
+    "noAvailableMembers": "Alle Vereinsmitglieder sind bereits in diesem Team",
+    "addAsMember": "Als Mitglied hinzufügen",
+    "addAsAdmin": "Als Administrator hinzufügen",
+    "promoteToAdmin": "Zum Administrator befördern",
+    "demoteToMember": "Zum Mitglied degradieren",
+    "roles": {
+      "admin": "Administrator",
+      "member": "Mitglied"
     }
   },
   "fines": {

--- a/Frontend/src/i18n/locales/en.json
+++ b/Frontend/src/i18n/locales/en.json
@@ -7,6 +7,7 @@
     "edit": "Edit",
     "delete": "Delete",
     "add": "Add",
+    "remove": "Remove",
     "create": "Create",
     "update": "Update",
     "submit": "Submit",
@@ -20,6 +21,8 @@
     "search": "Search",
     "filter": "Filter",
     "sort": "Sort",
+    "name": "Name",
+    "role": "Role",
     "actions": "Actions",
     "goToDashboard": "Go to Dashboard"
   },
@@ -66,6 +69,7 @@
     "latestNews": "Latest News",
     "overview": "Overview",
     "members": "Members",
+    "teams": "Teams",
     "roles": {
       "owner": "Owner",
       "admin": "Admin",
@@ -97,6 +101,29 @@
       "failedToUpdateSettings": "Failed to update settings",
       "loadingNews": "Error loading news: {{error}}",
       "loadingClub": "Error loading club details"
+    }
+  },
+  "teams": {
+    "title": "Teams",
+    "createTeam": "Create Team",
+    "editTeam": "Edit Team",
+    "teamName": "Team Name",
+    "teamNamePlaceholder": "Enter team name",
+    "description": "Description",
+    "descriptionPlaceholder": "Enter team description",
+    "deleteConfirmation": "Are you sure you want to delete this team?",
+    "membersOf": "Members of {{teamName}}",
+    "addMember": "Add Member",
+    "removeMemberConfirmation": "Are you sure you want to remove this member from the team?",
+    "joinedAt": "Joined",
+    "noAvailableMembers": "All club members are already in this team",
+    "addAsMember": "Add as Member",
+    "addAsAdmin": "Add as Admin",
+    "promoteToAdmin": "Promote to Admin",
+    "demoteToMember": "Demote to Member",
+    "roles": {
+      "admin": "Admin",
+      "member": "Member"
     }
   },
   "fines": {

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -1439,3 +1439,225 @@ input:disabled + .slider {
   text-shadow: none;
   opacity: 1;
 }
+
+/* Teams Management Styles */
+.teams-management {
+  padding: var(--space-md);
+}
+
+.teams-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-lg);
+  min-height: 500px;
+}
+
+.teams-list-section {
+  background: var(--color-background-light);
+  padding: var(--space-md);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.teams-grid {
+  display: grid;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.team-card {
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md);
+  padding: var(--space-md);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.team-card:hover {
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.team-card.selected {
+  border-color: var(--color-primary);
+  background: var(--color-background-light);
+  box-shadow: var(--shadow-md);
+}
+
+.team-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: var(--space-xs);
+}
+
+.team-header h4 {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 1.1rem;
+}
+
+.team-actions {
+  display: flex;
+  gap: var(--space-xs);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.team-card:hover .team-actions,
+.team-card.selected .team-actions {
+  opacity: 1;
+}
+
+.team-description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.team-members-section {
+  background: var(--color-background-light);
+  padding: var(--space-md);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-md);
+}
+
+.section-header h3 {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.members-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: var(--space-md);
+}
+
+.members-table th,
+.members-table td {
+  padding: var(--space-sm);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.members-table th {
+  background: var(--color-background);
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.members-table td {
+  color: var(--color-text);
+}
+
+.member-actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.available-members {
+  max-height: 300px;
+  overflow-y: auto;
+  margin: var(--space-md) 0;
+}
+
+.member-option {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  margin-bottom: var(--space-xs);
+  background: var(--color-background);
+}
+
+.role-actions {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.button-secondary {
+  background: var(--color-secondary);
+  color: white;
+  border: 1px solid var(--color-secondary);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--border-radius-sm);
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+}
+
+.button-secondary:hover {
+  background: var(--color-secondary-hover);
+  border-color: var(--color-secondary-hover);
+}
+
+.action-button.edit {
+  background: var(--color-secondary);
+  color: white;
+  border: 1px solid var(--color-secondary);
+}
+
+.action-button.edit:hover {
+  background: var(--color-secondary-hover);
+  border-color: var(--color-secondary-hover);
+}
+
+.action-button.promote {
+  background: var(--color-primary);
+  color: white;
+  border: 1px solid var(--color-primary);
+}
+
+.action-button.promote:hover {
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+.action-button.demote {
+  background: #ff9800;
+  color: white;
+  border: 1px solid #ff9800;
+}
+
+.action-button.demote:hover {
+  background: #f57c00;
+  border-color: #f57c00;
+}
+
+@media (max-width: 768px) {
+  .teams-layout {
+    grid-template-columns: 1fr;
+    gap: var(--space-md);
+  }
+  
+  .team-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  
+  .team-actions {
+    opacity: 1;
+    margin-top: var(--space-xs);
+  }
+  
+  .member-option {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-xs);
+  }
+  
+  .role-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}

--- a/Frontend/src/pages/clubs/admin/AdminClubDetails.tsx
+++ b/Frontend/src/pages/clubs/admin/AdminClubDetails.tsx
@@ -4,6 +4,7 @@ import api, { hardDeleteClub } from '../../../utils/api';
 import Layout from '../../../components/layout/Layout';
 import ClubNotFound from '../ClubNotFound';
 import AdminClubMemberList from './members/AdminClubMemberList';
+import AdminClubTeamList from './teams/AdminClubTeamList';
 import AdminClubFineList from './fines/AdminClubFineList';
 import AdminClubEventList from './events/AdminClubEventList';
 import AdminClubNewsList from './news/AdminClubNewsList';
@@ -182,6 +183,12 @@ const AdminClubDetails = () => {
                         >
                             {t('clubs.members')}
                         </button>
+                        <button 
+                            className={`tab-button ${activeTab === 'teams' ? 'active' : ''}`}
+                            onClick={() => setActiveTab('teams')}
+                        >
+                            {t('clubs.teams')}
+                        </button>
                         {clubSettings?.finesEnabled && (
                             <button 
                                 className={`tab-button ${activeTab === 'fines' ? 'active' : ''}`}
@@ -289,6 +296,10 @@ const AdminClubDetails = () => {
 
                         <div className={`tab-panel ${activeTab === 'members' ? 'active' : ''}`}>
                             <AdminClubMemberList />
+                        </div>
+
+                        <div className={`tab-panel ${activeTab === 'teams' ? 'active' : ''}`}>
+                            <AdminClubTeamList />
                         </div>
 
                         {clubSettings?.finesEnabled && (

--- a/Frontend/src/pages/clubs/admin/teams/AdminClubTeamList.tsx
+++ b/Frontend/src/pages/clubs/admin/teams/AdminClubTeamList.tsx
@@ -1,0 +1,426 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../../../../utils/api';
+import { useT } from '../../../../hooks/useTranslation';
+
+interface Team {
+    id: string;
+    name: string;
+    description: string;
+    createdAt: string;
+    clubId: string;
+}
+
+interface TeamMember {
+    id: string;
+    userId: string;
+    name: string;
+    role: 'admin' | 'member';
+    joinedAt: string;
+}
+
+interface ClubMember {
+    id: string;
+    userId: string;
+    name: string;
+    role: string;
+}
+
+const AdminClubTeamList = () => {
+    const { t } = useT();
+    const { id: clubId } = useParams();
+    const [teams, setTeams] = useState<Team[]>([]);
+    const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
+    const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
+    const [clubMembers, setClubMembers] = useState<ClubMember[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showCreateModal, setShowCreateModal] = useState(false);
+    const [showEditModal, setShowEditModal] = useState(false);
+    const [showAddMemberModal, setShowAddMemberModal] = useState(false);
+    const [newTeamName, setNewTeamName] = useState('');
+    const [newTeamDescription, setNewTeamDescription] = useState('');
+    const [editTeamName, setEditTeamName] = useState('');
+    const [editTeamDescription, setEditTeamDescription] = useState('');
+
+    const fetchTeams = useCallback(async () => {
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams`);
+            setTeams(response.data);
+        } catch {
+            setError('Failed to fetch teams');
+        }
+    }, [clubId]);
+
+    const fetchClubMembers = useCallback(async () => {
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/members`);
+            setClubMembers(response.data);
+        } catch {
+            setError('Failed to fetch club members');
+        }
+    }, [clubId]);
+
+    const fetchTeamMembers = useCallback(async (teamId: string) => {
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/members`);
+            // Ensure we always set an array, even if API returns null (prevents .map() crashes)
+            setTeamMembers(response.data || []);
+        } catch {
+            setError('Failed to fetch team members');
+            setTeamMembers([]); // Reset to empty array on error to prevent crashes
+        }
+    }, [clubId]);
+
+    useEffect(() => {
+        const loadData = async () => {
+            setLoading(true);
+            await Promise.all([fetchTeams(), fetchClubMembers()]);
+            setLoading(false);
+        };
+        loadData();
+    }, [fetchTeams, fetchClubMembers]);
+
+    useEffect(() => {
+        if (selectedTeam) {
+            fetchTeamMembers(selectedTeam.id);
+        }
+    }, [selectedTeam, fetchTeamMembers]);
+
+    const handleCreateTeam = async () => {
+        if (!newTeamName.trim()) return;
+
+        try {
+            await api.post(`/api/v1/clubs/${clubId}/teams`, {
+                name: newTeamName,
+                description: newTeamDescription
+            });
+            setNewTeamName('');
+            setNewTeamDescription('');
+            setShowCreateModal(false);
+            await fetchTeams();
+        } catch {
+            setError('Failed to create team');
+        }
+    };
+
+    const handleUpdateTeam = async () => {
+        if (!selectedTeam || !editTeamName.trim()) return;
+
+        try {
+            await api.put(`/api/v1/clubs/${clubId}/teams/${selectedTeam.id}`, {
+                name: editTeamName,
+                description: editTeamDescription
+            });
+            setShowEditModal(false);
+            await fetchTeams();
+            // Update selected team
+            setSelectedTeam(prev => prev ? { ...prev, name: editTeamName, description: editTeamDescription } : null);
+        } catch {
+            setError('Failed to update team');
+        }
+    };
+
+    const handleDeleteTeam = async (teamId: string) => {
+        if (!confirm(t('teams.deleteConfirmation'))) return;
+
+        try {
+            await api.delete(`/api/v1/clubs/${clubId}/teams/${teamId}`);
+            await fetchTeams();
+            if (selectedTeam?.id === teamId) {
+                setSelectedTeam(null);
+                setTeamMembers([]);
+            }
+        } catch {
+            setError('Failed to delete team');
+        }
+    };
+
+    const handleAddMember = async (userId: string, role: string) => {
+        if (!selectedTeam) return;
+
+        try {
+            await api.post(`/api/v1/clubs/${clubId}/teams/${selectedTeam.id}/members`, {
+                userId,
+                role
+            });
+            setShowAddMemberModal(false);
+            await fetchTeamMembers(selectedTeam.id);
+        } catch {
+            setError('Failed to add team member');
+        }
+    };
+
+    const handleUpdateMemberRole = async (memberId: string, newRole: string) => {
+        if (!selectedTeam) return;
+
+        try {
+            await api.patch(`/api/v1/clubs/${clubId}/teams/${selectedTeam.id}/members/${memberId}`, {
+                role: newRole
+            });
+            await fetchTeamMembers(selectedTeam.id);
+        } catch {
+            setError('Failed to update member role');
+        }
+    };
+
+    const handleRemoveMember = async (memberId: string) => {
+        if (!selectedTeam || !confirm(t('teams.removeMemberConfirmation'))) return;
+
+        try {
+            await api.delete(`/api/v1/clubs/${clubId}/teams/${selectedTeam.id}/members/${memberId}`);
+            await fetchTeamMembers(selectedTeam.id);
+        } catch {
+            setError('Failed to remove team member');
+        }
+    };
+
+    const openEditModal = (team: Team) => {
+        setSelectedTeam(team);
+        setEditTeamName(team.name);
+        setEditTeamDescription(team.description);
+        setShowEditModal(true);
+    };
+
+    const getAvailableMembers = () => {
+        // Use defensive programming to prevent crashes if teamMembers is null/undefined
+        const teamMemberIds = (teamMembers || []).map(tm => tm.userId);
+        return clubMembers.filter(cm => !teamMemberIds.includes(cm.userId));
+    };
+
+    if (loading) return <div>Loading teams...</div>;
+    if (error) return <div className="error">{error}</div>;
+
+    return (
+        <div className="teams-management">
+            <div className="teams-layout">
+                {/* Teams List */}
+                <div className="teams-list-section">
+                    <div className="section-header">
+                        <h3>{t('teams.title')}</h3>
+                        <button 
+                            onClick={() => setShowCreateModal(true)} 
+                            className="button-accept"
+                        >
+                            {t('teams.createTeam')}
+                        </button>
+                    </div>
+
+                    <div className="teams-grid">
+                        {teams.map(team => (
+                            <div 
+                                key={team.id} 
+                                className={`team-card ${selectedTeam?.id === team.id ? 'selected' : ''}`}
+                                onClick={() => setSelectedTeam(team)}
+                            >
+                                <div className="team-header">
+                                    <h4>{team.name}</h4>
+                                    <div className="team-actions">
+                                        <button 
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                openEditModal(team);
+                                            }}
+                                            className="action-button edit"
+                                        >
+                                            {t('common.edit')}
+                                        </button>
+                                        <button 
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleDeleteTeam(team.id);
+                                            }}
+                                            className="action-button remove"
+                                        >
+                                            {t('common.delete')}
+                                        </button>
+                                    </div>
+                                </div>
+                                {team.description && <p className="team-description">{team.description}</p>}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Team Members Section */}
+                {selectedTeam && (
+                    <div className="team-members-section">
+                        <div className="section-header">
+                            <h3>{t('teams.membersOf', { teamName: selectedTeam.name })}</h3>
+                            <button 
+                                onClick={() => setShowAddMemberModal(true)} 
+                                className="button-accept"
+                            >
+                                {t('teams.addMember')}
+                            </button>
+                        </div>
+
+                        <table className="members-table">
+                            <thead>
+                                <tr>
+                                    <th>{t('common.name')}</th>
+                                    <th>{t('common.role')}</th>
+                                    <th>{t('teams.joinedAt')}</th>
+                                    <th>{t('common.actions')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {teamMembers.length === 0 ? (
+                                    <tr>
+                                        <td colSpan={4} style={{textAlign: 'center', fontStyle: 'italic', padding: 'var(--space-lg)'}}>
+                                            {t('teams.noMembers') || 'No team members yet.'}
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    teamMembers.map(member => (
+                                        <tr key={member.id}>
+                                            <td>{member.name}</td>
+                                            <td>{t(`teams.roles.${member.role}`)}</td>
+                                            <td>{new Date(member.joinedAt).toLocaleDateString()}</td>
+                                            <td>
+                                                <div className="member-actions">
+                                                    {member.role === 'member' && (
+                                                        <button
+                                                            onClick={() => handleUpdateMemberRole(member.id, 'admin')}
+                                                            className="action-button promote"
+                                                        >
+                                                            {t('teams.promoteToAdmin')}
+                                                        </button>
+                                                    )}
+                                                    {member.role === 'admin' && (
+                                                        <button
+                                                            onClick={() => handleUpdateMemberRole(member.id, 'member')}
+                                                            className="action-button demote"
+                                                        >
+                                                            {t('teams.demoteToMember')}
+                                                        </button>
+                                                    )}
+                                                    <button
+                                                        onClick={() => handleRemoveMember(member.id)}
+                                                        className="action-button remove"
+                                                    >
+                                                        {t('common.remove')}
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+
+            {/* Create Team Modal */}
+            {showCreateModal && (
+                <div className="modal" onClick={() => setShowCreateModal(false)}>
+                    <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                        <h2>{t('teams.createTeam')}</h2>
+                        <div className="form-group">
+                            <label>{t('teams.teamName')}</label>
+                            <input
+                                type="text"
+                                value={newTeamName}
+                                onChange={(e) => setNewTeamName(e.target.value)}
+                                placeholder={t('teams.teamNamePlaceholder')}
+                            />
+                        </div>
+                        <div className="form-group">
+                            <label>{t('teams.description')}</label>
+                            <textarea
+                                value={newTeamDescription}
+                                onChange={(e) => setNewTeamDescription(e.target.value)}
+                                placeholder={t('teams.descriptionPlaceholder')}
+                                rows={3}
+                            />
+                        </div>
+                        <div className="modal-actions">
+                            <button onClick={handleCreateTeam} className="button-accept">
+                                {t('common.create')}
+                            </button>
+                            <button onClick={() => setShowCreateModal(false)} className="button-cancel">
+                                {t('common.cancel')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Edit Team Modal */}
+            {showEditModal && (
+                <div className="modal" onClick={() => setShowEditModal(false)}>
+                    <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                        <h2>{t('teams.editTeam')}</h2>
+                        <div className="form-group">
+                            <label>{t('teams.teamName')}</label>
+                            <input
+                                type="text"
+                                value={editTeamName}
+                                onChange={(e) => setEditTeamName(e.target.value)}
+                                placeholder={t('teams.teamNamePlaceholder')}
+                            />
+                        </div>
+                        <div className="form-group">
+                            <label>{t('teams.description')}</label>
+                            <textarea
+                                value={editTeamDescription}
+                                onChange={(e) => setEditTeamDescription(e.target.value)}
+                                placeholder={t('teams.descriptionPlaceholder')}
+                                rows={3}
+                            />
+                        </div>
+                        <div className="modal-actions">
+                            <button onClick={handleUpdateTeam} className="button-accept">
+                                {t('common.save')}
+                            </button>
+                            <button onClick={() => setShowEditModal(false)} className="button-cancel">
+                                {t('common.cancel')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Add Member Modal */}
+            {showAddMemberModal && (
+                <div className="modal" onClick={() => setShowAddMemberModal(false)}>
+                    <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                        <h2>{t('teams.addMember')}</h2>
+                        <div className="available-members">
+                            {getAvailableMembers().map(member => (
+                                <div key={member.id} className="member-option">
+                                    <span>{member.name}</span>
+                                    <div className="role-actions">
+                                        <button
+                                            onClick={() => handleAddMember(member.userId, 'member')}
+                                            className="button-accept"
+                                        >
+                                            {t('teams.addAsMember')}
+                                        </button>
+                                        <button
+                                            onClick={() => handleAddMember(member.userId, 'admin')}
+                                            className="button-secondary"
+                                        >
+                                            {t('teams.addAsAdmin')}
+                                        </button>
+                                    </div>
+                                </div>
+                            ))}
+                            {getAvailableMembers().length === 0 && (
+                                <p>{t('teams.noAvailableMembers')}</p>
+                            )}
+                        </div>
+                        <div className="modal-actions">
+                            <button onClick={() => setShowAddMemberModal(false)} className="button-cancel">
+                                {t('common.cancel')}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AdminClubTeamList;

--- a/Frontend/src/pages/clubs/admin/teams/__tests__/AdminClubTeamList.test.tsx
+++ b/Frontend/src/pages/clubs/admin/teams/__tests__/AdminClubTeamList.test.tsx
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { BrowserRouter } from 'react-router-dom'
+import '@testing-library/jest-dom'
+import AdminClubTeamList from '../AdminClubTeamList'
+
+// Mock the api module
+vi.mock('../../../../../utils/api', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn()
+  }
+}))
+
+// Mock react-router-dom useParams
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: () => ({ id: 'test-club-id' })
+  }
+})
+
+// Mock the translation hook
+vi.mock('../../../../../hooks/useTranslation', () => ({
+  useT: () => ({
+    t: (key: string, params?: { [key: string]: unknown }) => {
+      const translations: Record<string, string> = {
+        'teams.title': 'Teams',
+        'teams.createTeam': 'Create Team',
+        'teams.addMember': 'Add Member',
+        'teams.membersOf': `Members of ${params?.teamName || 'Team'}`,
+        'teams.noMembers': 'No team members yet.',
+        'common.name': 'Name',
+        'common.role': 'Role',
+        'common.actions': 'Actions',
+        'teams.joinedAt': 'Joined',
+        'teams.roles.admin': 'Admin',
+        'teams.roles.member': 'Member',
+        'teams.promoteToAdmin': 'Promote to Admin',
+        'teams.demoteToMember': 'Demote to Member',
+        'common.remove': 'Remove',
+        'common.edit': 'Edit',
+        'common.delete': 'Delete'
+      }
+      return translations[key] || key
+    }
+  })
+}))
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(
+    <BrowserRouter>
+      {component}
+    </BrowserRouter>
+  )
+}
+
+const mockTeams = [
+  {
+    id: 'team-1',
+    name: 'Empty Team',
+    description: 'A team with no members',
+    createdAt: '2024-01-01T00:00:00Z',
+    clubId: 'test-club-id'
+  },
+  {
+    id: 'team-2',
+    name: 'Team with Members',
+    description: 'A team with members',
+    createdAt: '2024-01-01T00:00:00Z',
+    clubId: 'test-club-id'
+  }
+]
+
+const mockClubMembers = [
+  {
+    id: 'member-1',
+    userId: 'user-1',
+    name: 'John Doe',
+    role: 'member'
+  },
+  {
+    id: 'member-2',
+    userId: 'user-2',
+    name: 'Jane Smith',
+    role: 'admin'
+  }
+]
+
+const mockTeamMembers = [
+  {
+    id: 'team-member-1',
+    userId: 'user-1',
+    name: 'John Doe',
+    role: 'member' as const,
+    joinedAt: '2024-01-01T00:00:00Z'
+  }
+]
+
+describe('AdminClubTeamList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock console methods to avoid cluttering test output
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('renders without crashing when loading', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock APIs to never resolve (simulate loading state)
+    mockGet.mockImplementation(() => new Promise(() => {}))
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    expect(screen.getByText('Loading teams...')).toBeInTheDocument()
+  })
+
+  it('renders teams list successfully', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Teams')).toBeInTheDocument()
+      expect(screen.getByText('Create Team')).toBeInTheDocument()
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+      expect(screen.getByText('Team with Members')).toBeInTheDocument()
+    })
+  })
+
+  it('handles team with no members without crashing', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+      .mockResolvedValueOnce({ data: [] }) // fetchTeamMembers - empty array
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+    })
+
+    // Click on the empty team
+    fireEvent.click(screen.getByText('Empty Team'))
+
+    // Wait for team members section to appear
+    await waitFor(() => {
+      expect(screen.getByText('Members of Empty Team')).toBeInTheDocument()
+      expect(screen.getByText('No team members yet.')).toBeInTheDocument()
+      expect(screen.getByText('Add Member')).toBeInTheDocument()
+    })
+
+    // Ensure table headers are present
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Role')).toBeInTheDocument()
+    expect(screen.getByText('Joined')).toBeInTheDocument()
+    expect(screen.getByText('Actions')).toBeInTheDocument()
+  })
+
+  it('handles team with null members response without crashing', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+      .mockResolvedValueOnce({ data: null }) // fetchTeamMembers - null response
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+    })
+
+    // Click on the empty team
+    fireEvent.click(screen.getByText('Empty Team'))
+
+    // Wait for team members section to appear
+    await waitFor(() => {
+      expect(screen.getByText('Members of Empty Team')).toBeInTheDocument()
+      expect(screen.getByText('No team members yet.')).toBeInTheDocument()
+    })
+
+    // The component should not crash and should show empty state
+    expect(screen.queryByText('TypeError')).not.toBeInTheDocument()
+  })
+
+  it('handles API error when fetching team members', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses for initial load
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+      .mockRejectedValueOnce(new Error('API Error')) // fetchTeamMembers - error
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+    })
+
+    // Click on the empty team
+    fireEvent.click(screen.getByText('Empty Team'))
+
+    // Should show error but not crash
+    await waitFor(() => {
+      expect(screen.getByText('Failed to fetch team members')).toBeInTheDocument()
+    })
+  })
+
+  it('renders team with members correctly', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+      .mockResolvedValueOnce({ data: mockTeamMembers }) // fetchTeamMembers
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(screen.getByText('Team with Members')).toBeInTheDocument()
+    })
+
+    // Click on the team with members
+    fireEvent.click(screen.getByText('Team with Members'))
+
+    // Wait for team members section to appear
+    await waitFor(() => {
+      expect(screen.getByText('Members of Team with Members')).toBeInTheDocument()
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+      expect(screen.getByText('Member')).toBeInTheDocument()
+    })
+
+    // Should not show empty state message
+    expect(screen.queryByText('No team members yet.')).not.toBeInTheDocument()
+  })
+
+  it('shows add member modal with available members when team has no members', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock successful API responses
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams }) // fetchTeams
+      .mockResolvedValueOnce({ data: mockClubMembers }) // fetchClubMembers
+      .mockResolvedValueOnce({ data: [] }) // fetchTeamMembers - empty
+
+    renderWithRouter(<AdminClubTeamList />)
+
+    // Wait for initial load and select empty team
+    await waitFor(() => {
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Empty Team'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Member')).toBeInTheDocument()
+    })
+
+    // Click Add Member button
+    fireEvent.click(screen.getByText('Add Member'))
+
+    // Should show all club members as available (since team is empty)
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument()
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+    })
+  })
+
+  it('prevents regression: teamMembers.map crash when teamMembers is null', async () => {
+    const { default: api } = await import('../../../../../utils/api')
+    const mockGet = vi.mocked(api.get)
+    
+    // Mock APIs returning data that could cause the original crash
+    mockGet
+      .mockResolvedValueOnce({ data: mockTeams })
+      .mockResolvedValueOnce({ data: mockClubMembers })
+      .mockResolvedValueOnce({ data: null }) // This would have caused the crash
+
+    // This test specifically ensures the component doesn't crash
+    expect(() => {
+      renderWithRouter(<AdminClubTeamList />)
+    }).not.toThrow()
+
+    await waitFor(() => {
+      expect(screen.getByText('Empty Team')).toBeInTheDocument()
+    })
+
+    // Clicking on team should not crash
+    expect(() => {
+      fireEvent.click(screen.getByText('Empty Team'))
+    }).not.toThrow()
+
+    // Component should handle null gracefully
+    await waitFor(() => {
+      expect(screen.getByText('No team members yet.')).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
- Added Team and TeamMember models with necessary CRUD operations in the backend.
- Implemented team creation, retrieval, updating, and deletion features.
- Added functionality to manage team members, including adding, removing, and updating roles.
- Developed AdminClubTeamList component in the frontend for club admins to manage teams and members.
- Integrated API calls for fetching teams, club members, and team members.
- Created modals for creating and editing teams, as well as adding members.
- Added tests for AdminClubTeamList to ensure proper rendering and functionality.