### PR TITLE
Add team event support

### DIFF
--- a/Backend/handlers/api.go
+++ b/Backend/handlers/api.go
@@ -19,6 +19,7 @@ func Handler_v1() http.Handler {
 	registerTeamRoutes(mux)
 	registerShiftRoutes(mux)
 	registerEventRoutes(mux)
+	registerTeamEventRoutes(mux)
 	registerNewsRoutes(mux)
 	registerJoinRequestRoutes(mux)
 	registerInviteRoutes(mux)

--- a/Backend/handlers/team_events.go
+++ b/Backend/handlers/team_events.go
@@ -1,0 +1,371 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/NLstn/clubs/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// registerTeamEventRoutes registers routes for team events
+func registerTeamEventRoutes(mux *http.ServeMux) {
+	base := "/api/v1/clubs/{clubid}/teams/{teamid}/events"
+
+	mux.Handle(base, RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleGetTeamEvents(w, r)
+		case http.MethodPost:
+			handleCreateTeamEvent(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	mux.Handle(base+"/{eventid}", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			handleGetTeamEvent(w, r)
+		case http.MethodPut:
+			handleUpdateTeamEvent(w, r)
+		case http.MethodDelete:
+			handleDeleteTeamEvent(w, r)
+		default:
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	mux.Handle(base+"/upcoming", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			handleGetTeamUpcomingEvents(w, r)
+		} else {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	mux.Handle(base+"/{eventid}/rsvp", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			handleCreateOrUpdateTeamEventRSVP(w, r)
+		} else {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+
+	mux.Handle(base+"/{eventid}/rsvps", RateLimitMiddleware(apiLimiter)(withAuth(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			handleGetTeamEventRSVPs(w, r)
+		} else {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
+}
+
+// helper to fetch club and team and validate IDs
+func getClubAndTeam(r *http.Request, w http.ResponseWriter) (models.Club, models.Team, bool) {
+	user := extractUser(r)
+	clubID := extractPathParam(r, "clubs")
+	teamID := extractPathParam(r, "teams")
+
+	if _, err := uuid.Parse(clubID); err != nil {
+		http.Error(w, "Invalid club ID format", http.StatusBadRequest)
+		return models.Club{}, models.Team{}, false
+	}
+	if _, err := uuid.Parse(teamID); err != nil {
+		http.Error(w, "Invalid team ID format", http.StatusBadRequest)
+		return models.Club{}, models.Team{}, false
+	}
+
+	club, err := models.GetClubByID(clubID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Club not found", http.StatusNotFound)
+		return models.Club{}, models.Team{}, false
+	} else if err != nil {
+		http.Error(w, "Failed to get club information", http.StatusInternalServerError)
+		return models.Club{}, models.Team{}, false
+	}
+
+	team, err := models.GetTeamByID(teamID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Team not found", http.StatusNotFound)
+		return models.Club{}, models.Team{}, false
+	} else if err != nil {
+		http.Error(w, "Failed to get team information", http.StatusInternalServerError)
+		return models.Club{}, models.Team{}, false
+	}
+
+	if team.ClubID != club.ID {
+		http.Error(w, "Team does not belong to club", http.StatusBadRequest)
+		return models.Club{}, models.Team{}, false
+	}
+
+	// Check membership for general access
+	if !team.IsMember(user) && !club.IsAdmin(user) {
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return models.Club{}, models.Team{}, false
+	}
+
+	return club, team, true
+}
+
+// GET /api/v1/clubs/{clubid}/teams/{teamid}/events
+func handleGetTeamEvents(w http.ResponseWriter, r *http.Request) {
+	_, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+
+	events, err := team.GetEvents()
+	if err != nil {
+		http.Error(w, "Failed to get events", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(events)
+}
+
+// GET /api/v1/clubs/{clubid}/teams/{teamid}/events/{eventid}
+func handleGetTeamEvent(w http.ResponseWriter, r *http.Request) {
+	user := extractUser(r)
+	_, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+	eventID := extractPathParam(r, "events")
+	if _, err := uuid.Parse(eventID); err != nil {
+		http.Error(w, "Invalid event ID format", http.StatusBadRequest)
+		return
+	}
+
+	event, err := team.GetEventByID(eventID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Event not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, "Failed to get event", http.StatusInternalServerError)
+		return
+	}
+
+	userRSVP, _ := user.GetUserTeamEventRSVP(eventID)
+	response := struct {
+		*models.TeamEvent
+		UserRSVP *models.TeamEventRSVP `json:"user_rsvp,omitempty"`
+	}{event, userRSVP}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// POST /api/v1/clubs/{clubid}/teams/{teamid}/events
+func handleCreateTeamEvent(w http.ResponseWriter, r *http.Request) {
+	type CreateEventRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Location    string `json:"location"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+	}
+
+	user := extractUser(r)
+	club, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+
+	if !team.IsAdmin(user) && !club.IsAdmin(user) {
+		http.Error(w, "Unauthorized - admin access required", http.StatusForbidden)
+		return
+	}
+
+	var req CreateEventRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	startTime, err := time.Parse(time.RFC3339, req.StartTime)
+	if err != nil {
+		http.Error(w, "Invalid start time format. Expected RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+	endTime, err := time.Parse(time.RFC3339, req.EndTime)
+	if err != nil {
+		http.Error(w, "Invalid end time format. Expected RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+
+	event, err := team.CreateEvent(req.Name, req.Description, req.Location, startTime, endTime, user.ID)
+	if err != nil {
+		http.Error(w, "Failed to create event", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(event)
+}
+
+// PUT /api/v1/clubs/{clubid}/teams/{teamid}/events/{eventid}
+func handleUpdateTeamEvent(w http.ResponseWriter, r *http.Request) {
+	type UpdateEventRequest struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Location    string `json:"location"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+	}
+
+	user := extractUser(r)
+	club, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+
+	if !team.IsAdmin(user) && !club.IsAdmin(user) {
+		http.Error(w, "Unauthorized - admin access required", http.StatusForbidden)
+		return
+	}
+
+	eventID := extractPathParam(r, "events")
+	if _, err := uuid.Parse(eventID); err != nil {
+		http.Error(w, "Invalid event ID format", http.StatusBadRequest)
+		return
+	}
+
+	var req UpdateEventRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	startTime, err := time.Parse(time.RFC3339, req.StartTime)
+	if err != nil {
+		http.Error(w, "Invalid start time format. Expected RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+	endTime, err := time.Parse(time.RFC3339, req.EndTime)
+	if err != nil {
+		http.Error(w, "Invalid end time format. Expected RFC3339 timestamp", http.StatusBadRequest)
+		return
+	}
+
+	event, err := team.UpdateEvent(eventID, req.Name, req.Description, req.Location, startTime, endTime, user.ID)
+	if err == gorm.ErrRecordNotFound {
+		http.Error(w, "Event not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		http.Error(w, "Failed to update event", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(event)
+}
+
+// DELETE /api/v1/clubs/{clubid}/teams/{teamid}/events/{eventid}
+func handleDeleteTeamEvent(w http.ResponseWriter, r *http.Request) {
+	user := extractUser(r)
+	club, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+
+	if !team.IsAdmin(user) && !club.IsAdmin(user) {
+		http.Error(w, "Unauthorized - admin access required", http.StatusForbidden)
+		return
+	}
+
+	eventID := extractPathParam(r, "events")
+	if _, err := uuid.Parse(eventID); err != nil {
+		http.Error(w, "Invalid event ID format", http.StatusBadRequest)
+		return
+	}
+
+	if err := team.DeleteEvent(eventID); err != nil {
+		http.Error(w, "Failed to delete event", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GET /api/v1/clubs/{clubid}/teams/{teamid}/events/upcoming
+func handleGetTeamUpcomingEvents(w http.ResponseWriter, r *http.Request) {
+	_, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+	events, err := team.GetUpcomingEvents()
+	if err != nil {
+		http.Error(w, "Failed to get events", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(events)
+}
+
+// POST /api/v1/clubs/{clubid}/teams/{teamid}/events/{eventid}/rsvp
+func handleCreateOrUpdateTeamEventRSVP(w http.ResponseWriter, r *http.Request) {
+	user := extractUser(r)
+	_, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+	eventID := extractPathParam(r, "events")
+	if _, err := uuid.Parse(eventID); err != nil {
+		http.Error(w, "Invalid event ID format", http.StatusBadRequest)
+		return
+	}
+
+	type RSVPRequest struct {
+		Response string `json:"response"`
+	}
+	var req RSVPRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if !team.IsMember(user) {
+		http.Error(w, "Unauthorized", http.StatusForbidden)
+		return
+	}
+
+	if err := user.CreateOrUpdateTeamEventRSVP(eventID, req.Response); err != nil {
+		http.Error(w, "Failed to update RSVP", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GET /api/v1/clubs/{clubid}/teams/{teamid}/events/{eventid}/rsvps
+func handleGetTeamEventRSVPs(w http.ResponseWriter, r *http.Request) {
+	_, team, ok := getClubAndTeam(r, w)
+	if !ok {
+		return
+	}
+	eventID := extractPathParam(r, "events")
+	if _, err := uuid.Parse(eventID); err != nil {
+		http.Error(w, "Invalid event ID format", http.StatusBadRequest)
+		return
+	}
+	rsvps, err := models.GetTeamEventRSVPs(eventID)
+	if err != nil {
+		http.Error(w, "Failed to get RSVPs", http.StatusInternalServerError)
+		return
+	}
+
+	counts, err := models.GetTeamEventRSVPCounts(eventID)
+	if err != nil {
+		http.Error(w, "Failed to get RSVP counts", http.StatusInternalServerError)
+		return
+	}
+
+	response := struct {
+		RSVPs  []models.TeamEventRSVP `json:"rsvps"`
+		Counts map[string]int         `json:"counts"`
+	}{rsvps, counts}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}

--- a/Backend/main.go
+++ b/Backend/main.go
@@ -39,6 +39,8 @@ func main() {
 		&models.ShiftMember{},
 		&models.Event{},
 		&models.EventRSVP{},
+		&models.TeamEvent{},
+		&models.TeamEventRSVP{},
 		&models.News{},
 		&models.ClubSettings{},
 		&models.Notification{},

--- a/Backend/models/team_events.go
+++ b/Backend/models/team_events.go
@@ -1,0 +1,159 @@
+package models
+
+import (
+	"time"
+
+	"github.com/NLstn/clubs/database"
+)
+
+// TeamEvent represents an event that belongs to a team within a club
+// It mirrors the Event model but references a team instead of a club
+// and uses TeamEventRSVP for RSVP tracking.
+type TeamEvent struct {
+	ID          string    `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	TeamID      string    `gorm:"type:uuid;not null" json:"team_id"`
+	Name        string    `gorm:"not null" json:"name"`
+	Description string    `gorm:"type:text" json:"description"`
+	Location    string    `gorm:"type:varchar(255)" json:"location"`
+	StartTime   time.Time `gorm:"not null" json:"start_time"`
+	EndTime     time.Time `gorm:"not null" json:"end_time"`
+	CreatedAt   time.Time `json:"created_at"`
+	CreatedBy   string    `json:"created_by" gorm:"type:uuid"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	UpdatedBy   string    `json:"updated_by" gorm:"type:uuid"`
+}
+
+// TeamEventRSVP stores RSVP responses for team events
+// mirroring EventRSVP but for TeamEvent.
+type TeamEventRSVP struct {
+	ID        string    `gorm:"type:uuid;default:gen_random_uuid();primaryKey" json:"id"`
+	EventID   string    `gorm:"type:uuid;not null" json:"event_id"`
+	UserID    string    `gorm:"type:uuid;not null" json:"user_id"`
+	Response  string    `gorm:"not null" json:"response"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	Event TeamEvent `gorm:"foreignKey:EventID" json:"event,omitempty"`
+	User  User      `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+// CreateEvent creates a new event for the team
+func (t *Team) CreateEvent(name, description, location string, startTime, endTime time.Time, createdBy string) (*TeamEvent, error) {
+	event := TeamEvent{
+		TeamID:      t.ID,
+		Name:        name,
+		Description: description,
+		Location:    location,
+		StartTime:   startTime,
+		EndTime:     endTime,
+		CreatedBy:   createdBy,
+		UpdatedBy:   createdBy,
+	}
+
+	if err := database.Db.Create(&event).Error; err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// GetEvents returns all events for the team
+func (t *Team) GetEvents() ([]TeamEvent, error) {
+	var events []TeamEvent
+	err := database.Db.Where("team_id = ?", t.ID).Order("start_time ASC").Find(&events).Error
+	return events, err
+}
+
+// GetUpcomingEvents returns upcoming events for the team
+func (t *Team) GetUpcomingEvents() ([]TeamEvent, error) {
+	var events []TeamEvent
+	now := time.Now()
+	err := database.Db.Where("team_id = ? AND start_time >= ?", t.ID, now).Order("start_time ASC").Find(&events).Error
+	return events, err
+}
+
+// UpdateEvent updates an existing team event
+func (t *Team) UpdateEvent(eventID, name, description, location string, startTime, endTime time.Time, updatedBy string) (*TeamEvent, error) {
+	var event TeamEvent
+	if err := database.Db.Where("id = ? AND team_id = ?", eventID, t.ID).First(&event).Error; err != nil {
+		return nil, err
+	}
+
+	event.Name = name
+	event.Description = description
+	event.Location = location
+	event.StartTime = startTime
+	event.EndTime = endTime
+	event.UpdatedBy = updatedBy
+
+	if err := database.Db.Save(&event).Error; err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// DeleteEvent deletes a team event and its RSVPs
+func (t *Team) DeleteEvent(eventID string) error {
+	if err := database.Db.Where("event_id = ?", eventID).Delete(&TeamEventRSVP{}).Error; err != nil {
+		return err
+	}
+	return database.Db.Where("id = ? AND team_id = ?", eventID, t.ID).Delete(&TeamEvent{}).Error
+}
+
+// GetEventByID returns a team event by ID
+func (t *Team) GetEventByID(eventID string) (*TeamEvent, error) {
+	var event TeamEvent
+	if err := database.Db.Where("id = ? AND team_id = ?", eventID, t.ID).First(&event).Error; err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// CreateOrUpdateTeamEventRSVP creates or updates an RSVP for a team event
+func (u *User) CreateOrUpdateTeamEventRSVP(eventID, response string) error {
+	var rsvp TeamEventRSVP
+	err := database.Db.Where("event_id = ? AND user_id = ?", eventID, u.ID).First(&rsvp).Error
+	if err != nil {
+		rsvp = TeamEventRSVP{EventID: eventID, UserID: u.ID, Response: response}
+		return database.Db.Create(&rsvp).Error
+	}
+	rsvp.Response = response
+	return database.Db.Save(&rsvp).Error
+}
+
+// GetTeamEventRSVPs returns all RSVPs for a team event
+func GetTeamEventRSVPs(eventID string) ([]TeamEventRSVP, error) {
+	var rsvps []TeamEventRSVP
+	err := database.Db.Where("event_id = ?", eventID).Preload("User").Find(&rsvps).Error
+	return rsvps, err
+}
+
+// GetTeamEventRSVPCounts returns RSVP counts for a team event
+func GetTeamEventRSVPCounts(eventID string) (map[string]int, error) {
+	var results []struct {
+		Response string
+		Count    int
+	}
+
+	err := database.Db.Table("team_event_rsvps").
+		Select("response, COUNT(*) as count").
+		Where("event_id = ?", eventID).
+		Group("response").
+		Scan(&results).Error
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int)
+	for _, r := range results {
+		counts[r.Response] = r.Count
+	}
+	return counts, nil
+}
+
+// GetUserTeamEventRSVP returns a user's RSVP for a team event
+func (u *User) GetUserTeamEventRSVP(eventID string) (*TeamEventRSVP, error) {
+	var rsvp TeamEventRSVP
+	if err := database.Db.Where("event_id = ? AND user_id = ?", eventID, u.ID).First(&rsvp).Error; err != nil {
+		return nil, err
+	}
+	return &rsvp, nil
+}

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -22,6 +22,8 @@ const ProfilePrivacy = lazy(() => import('./pages/profile/ProfilePrivacy'));
 const ProfileNotificationSettings = lazy(() => import('./pages/profile/ProfileNotificationSettings'));
 const EventDetails = lazy(() => import('./pages/clubs/events/EventDetails'));
 const AdminEventDetails = lazy(() => import('./pages/clubs/admin/events/AdminEventDetails'));
+const TeamEventDetails = lazy(() => import('./pages/teams/events/EventDetails'));
+const AdminTeamEventList = lazy(() => import('./pages/teams/admin/events/AdminTeamEventList'));
 
 // Loading component for suspense fallback
 const PageLoader = () => (
@@ -86,6 +88,24 @@ function App() {
                             element={
                                 <ProtectedRoute>
                                     <AdminEventDetails />
+                                </ProtectedRoute>
+                            }
+                        />
+
+                        <Route
+                            path="/clubs/:clubId/teams/:teamId/events/:eventId"
+                            element={
+                                <ProtectedRoute>
+                                    <TeamEventDetails />
+                                </ProtectedRoute>
+                            }
+                        />
+
+                        <Route
+                            path="/clubs/:clubId/teams/:teamId/admin/events"
+                            element={
+                                <ProtectedRoute>
+                                    <AdminTeamEventList />
                                 </ProtectedRoute>
                             }
                         />

--- a/Frontend/src/pages/teams/UpcomingEvents.tsx
+++ b/Frontend/src/pages/teams/UpcomingEvents.tsx
@@ -1,0 +1,108 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import api from '../../utils/api';
+
+interface Event {
+    id: string;
+    name: string;
+    description: string;
+    location: string;
+    start_time: string;
+    end_time: string;
+    user_rsvp?: {
+        response: string;
+    };
+}
+
+const TeamUpcomingEvents = () => {
+    const { clubId, teamId } = useParams();
+    const [events, setEvents] = useState<Event[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchUpcomingEvents = async () => {
+        if (!clubId || !teamId) return;
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/events/upcoming`);
+            setEvents(response.data || []);
+        } catch (err) {
+            console.error('Error fetching upcoming team events:', err);
+            setError('Failed to load upcoming events');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchUpcomingEvents();
+    }, [clubId, teamId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleRSVP = async (eventId: string, response: string) => {
+        if (!clubId || !teamId) return;
+        try {
+            await api.post(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${eventId}/rsvp`, { response });
+            fetchUpcomingEvents();
+        } catch (err) {
+            console.error('Error updating RSVP:', err);
+            alert('Failed to update RSVP. Please try again.');
+        }
+    };
+
+    const formatDateTime = (timestamp: string) => {
+        try {
+            const dateTime = new Date(timestamp);
+            return dateTime.toLocaleString();
+        } catch {
+            return timestamp;
+        }
+    };
+
+    if (loading) return <div>Loading upcoming events...</div>;
+    if (error) return <div className="error">{error}</div>;
+    if (events.length === 0) return <div>No upcoming events.</div>;
+
+    return (
+        <div>
+            <h3>Upcoming Team Events</h3>
+            <div className="events-list">
+                {events.map(event => (
+                    <div key={event.id} className="event-card">
+                        <div className="event-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+                            <h4 style={{ margin: 0 }}>{event.name}</h4>
+                            <Link
+                                to={`/clubs/${clubId}/teams/${teamId}/events/${event.id}`}
+                                className="button-info"
+                            >
+                                View Details
+                            </Link>
+                        </div>
+                        <p><strong>Start:</strong> {formatDateTime(event.start_time)}</p>
+                        <p><strong>End:</strong> {formatDateTime(event.end_time)}</p>
+                        {event.location && (
+                            <p><strong>Location:</strong> {event.location}</p>
+                        )}
+                        <div className="rsvp-section">
+                            <p>
+                                <strong>RSVP:</strong>
+                                {event.user_rsvp ? (
+                                    <span className={`rsvp-status ${event.user_rsvp.response}`}>
+                                        {event.user_rsvp.response === 'yes' ? 'Yes' : event.user_rsvp.response === 'no' ? 'No' : 'Maybe'}
+                                    </span>
+                                ) : (
+                                    <span className="rsvp-status none">No response</span>
+                                )}
+                            </p>
+                            <div className="rsvp-buttons">
+                                <button onClick={() => handleRSVP(event.id, 'yes')} className={event.user_rsvp?.response === 'yes' ? 'button-accept' : 'button'}>Yes</button>
+                                <button onClick={() => handleRSVP(event.id, 'maybe')} className={event.user_rsvp?.response === 'maybe' ? 'button-maybe' : 'button'}>Maybe</button>
+                                <button onClick={() => handleRSVP(event.id, 'no')} className={event.user_rsvp?.response === 'no' ? 'button-cancel' : 'button'}>No</button>
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default TeamUpcomingEvents;

--- a/Frontend/src/pages/teams/admin/events/AddEvent.tsx
+++ b/Frontend/src/pages/teams/admin/events/AddEvent.tsx
@@ -1,0 +1,95 @@
+import { FC, useState } from "react";
+import api from "../../../../utils/api";
+import { Input, Modal } from '@/components/ui';
+
+interface AddEventProps {
+    isOpen: boolean;
+    onClose: () => void;
+    clubId: string;
+    teamId: string;
+    onSuccess: () => void;
+}
+
+const AddEvent: FC<AddEventProps> = ({ isOpen, onClose, clubId, teamId, onSuccess }) => {
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [location, setLocation] = useState('');
+    const [startTime, setStartTime] = useState('');
+    const [endTime, setEndTime] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    if (!isOpen) return null;
+
+    const handleSubmit = async () => {
+        if (!name || !startTime || !endTime) {
+            setError("Please fill in all required fields (name, start time, and end time)");
+            return;
+        }
+        const startDateTime = new Date(startTime);
+        const endDateTime = new Date(endTime);
+        if (startDateTime >= endDateTime) {
+            setError("End date/time must be after start date/time");
+            return;
+        }
+        setError(null);
+        setIsSubmitting(true);
+        try {
+            await api.post(`/api/v1/clubs/${clubId}/teams/${teamId}/events`, {
+                name,
+                description,
+                location,
+                start_time: startDateTime.toISOString(),
+                end_time: endDateTime.toISOString()
+            });
+            setName('');
+            setDescription('');
+            setLocation('');
+            setStartTime('');
+            setEndTime('');
+            onSuccess();
+            onClose();
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                setError("Failed to add event: " + error.message);
+            } else {
+                setError("Failed to add event: Unknown error");
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleClose = () => {
+        setName('');
+        setDescription('');
+        setLocation('');
+        setStartTime('');
+        setEndTime('');
+        setError(null);
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} title="Add Event">
+            <Modal.Error error={error} />
+            <Modal.Body>
+                <div className="modal-form-section">
+                    <Input label="Event Name" id="eventName" type="text" value={name} onChange={(e) => setName(e.target.value)} placeholder="Event Name" disabled={isSubmitting} />
+                    <Input label="Description" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="Event description (optional)" disabled={isSubmitting} multiline rows={3} />
+                    <Input label="Location" id="eventLocation" type="text" value={location} onChange={(e) => setLocation(e.target.value)} placeholder="Event location (optional)" disabled={isSubmitting} />
+                    <Input label="Start Date & Time" id="startTime" type="datetime-local" value={startTime} onChange={(e) => setStartTime(e.target.value)} disabled={isSubmitting} />
+                    <Input label="End Date & Time" id="endTime" type="datetime-local" value={endTime} onChange={(e) => setEndTime(e.target.value)} disabled={isSubmitting} />
+                </div>
+            </Modal.Body>
+            <Modal.Actions>
+                <button onClick={handleSubmit} className="button-accept" disabled={isSubmitting}>
+                    {isSubmitting ? (<><Modal.LoadingSpinner />Adding...</>) : 'Add Event'}
+                </button>
+                <button onClick={handleClose} className="button-cancel" disabled={isSubmitting}>Cancel</button>
+            </Modal.Actions>
+        </Modal>
+    );
+};
+
+export default AddEvent;

--- a/Frontend/src/pages/teams/admin/events/AdminTeamEventList.tsx
+++ b/Frontend/src/pages/teams/admin/events/AdminTeamEventList.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import EditEvent from "./EditEvent";
+import AddEvent from "./AddEvent";
+import EventRSVPList from "./EventRSVPList";
+import { Table, TableColumn } from '@/components/ui';
+import api from "../../../../utils/api";
+
+interface Event {
+    id: string;
+    name: string;
+    description: string;
+    location: string;
+    start_time: string;
+    end_time: string;
+}
+
+interface RSVPCounts {
+    yes?: number;
+    no?: number;
+    maybe?: number;
+}
+
+const AdminTeamEventList = () => {
+    const { clubId, teamId } = useParams();
+    const [events, setEvents] = useState<Event[]>([]);
+    const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+    const [isRSVPModalOpen, setIsRSVPModalOpen] = useState(false);
+    const [selectedEventForRSVP, setSelectedEventForRSVP] = useState<Event | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [rsvpCounts, setRsvpCounts] = useState<Record<string, RSVPCounts>>({});
+
+    const fetchEvents = useCallback(async () => {
+        if (!clubId || !teamId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/events`);
+            setEvents(response.data || []);
+            const counts: Record<string, RSVPCounts> = {};
+            for (const event of response.data || []) {
+                try {
+                    const rsvpResponse = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${event.id}/rsvps`);
+                    counts[event.id] = rsvpResponse.data.counts || {};
+                } catch (err) {
+                    counts[event.id] = {};
+                }
+            }
+            setRsvpCounts(counts);
+        } catch (err) {
+            console.error('Error fetching events:', err);
+            setError('Failed to fetch events');
+            setEvents([]);
+        } finally {
+            setLoading(false);
+        }
+    }, [clubId, teamId]);
+
+    useEffect(() => {
+        fetchEvents();
+    }, [fetchEvents]);
+
+    const handleEditEvent = (event: Event) => {
+        setSelectedEvent(event);
+        setIsEditModalOpen(true);
+    };
+
+    const handleCloseEditModal = () => {
+        setSelectedEvent(null);
+        setIsEditModalOpen(false);
+    };
+
+    const handleViewRSVPs = (event: Event) => {
+        setSelectedEventForRSVP(event);
+        setIsRSVPModalOpen(true);
+    };
+
+    const handleCloseRSVPModal = () => {
+        setSelectedEventForRSVP(null);
+        setIsRSVPModalOpen(false);
+    };
+
+    const handleDeleteEvent = async (eventId: string) => {
+        if (!clubId || !teamId) return;
+        if (!confirm("Are you sure you want to delete this event? This will also delete all RSVPs.")) {
+            return;
+        }
+        try {
+            await api.delete(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${eventId}`);
+            fetchEvents();
+        } catch (err) {
+            console.error('Error deleting event:', err);
+            setError('Failed to delete event');
+        }
+    };
+
+    const formatDateTime = (timestamp: string) => {
+        try {
+            const dateTime = new Date(timestamp);
+            return dateTime.toLocaleString();
+        } catch {
+            return timestamp;
+        }
+    };
+
+    const eventColumns: TableColumn<Event>[] = [
+        { key: 'name', header: 'Name', render: (event) => event.name },
+        { key: 'start_time', header: 'Start', render: (event) => formatDateTime(event.start_time) },
+        { key: 'end_time', header: 'End', render: (event) => formatDateTime(event.end_time) },
+        {
+            key: 'rsvps',
+            header: 'RSVPs',
+            render: (event) => {
+                const counts = rsvpCounts[event.id] || {};
+                const yesCount = counts.yes || 0;
+                const noCount = counts.no || 0;
+                const maybeCount = counts.maybe || 0;
+                return (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                        <div>
+                            <span style={{color: 'green'}}>Yes: {yesCount}</span>{' '}
+                            <span style={{color: 'red'}}>No: {noCount}</span>{' '}
+                            <span style={{color: 'orange'}}>Maybe: {maybeCount}</span>
+                        </div>
+                        {(yesCount > 0 || noCount > 0 || maybeCount > 0) && (
+                            <button onClick={() => handleViewRSVPs(event)} className="button" style={{ fontSize: '0.8em', padding: '4px 10px' }}>View Details</button>
+                        )}
+                    </div>
+                );
+            }
+        },
+        {
+            key: 'actions',
+            header: 'Actions',
+            render: (event) => (
+                <div style={{ display: 'flex', gap: '8px' }}>
+                    <button onClick={() => handleEditEvent(event)} className="button">Edit</button>
+                    <button onClick={() => handleDeleteEvent(event.id)} className="button-cancel">Delete</button>
+                </div>
+            )
+        }
+    ];
+
+    if (loading) return <div>Loading events...</div>;
+    if (error) return <div className="error">{error}</div>;
+
+    return (
+        <div>
+            <h2>Team Events</h2>
+            <button onClick={() => setIsAddModalOpen(true)} className="button-accept" style={{ marginBottom: '10px' }}>
+                Add Event
+            </button>
+            <Table columns={eventColumns} data={events} keyExtractor={(event) => event.id} emptyMessage="No events found." />
+
+            <AddEvent
+                isOpen={isAddModalOpen}
+                onClose={() => setIsAddModalOpen(false)}
+                clubId={clubId || ''}
+                teamId={teamId || ''}
+                onSuccess={fetchEvents}
+            />
+            <EditEvent
+                isOpen={isEditModalOpen}
+                onClose={handleCloseEditModal}
+                clubId={clubId || ''}
+                teamId={teamId || ''}
+                event={selectedEvent}
+                onSuccess={fetchEvents}
+            />
+            {selectedEventForRSVP && (
+                <EventRSVPList
+                    isOpen={isRSVPModalOpen}
+                    onClose={handleCloseRSVPModal}
+                    eventId={selectedEventForRSVP.id}
+                    eventName={selectedEventForRSVP.name}
+                    clubId={clubId || ''}
+                    teamId={teamId || ''}
+                />
+            )}
+        </div>
+    );
+};
+
+export default AdminTeamEventList;

--- a/Frontend/src/pages/teams/admin/events/EditEvent.tsx
+++ b/Frontend/src/pages/teams/admin/events/EditEvent.tsx
@@ -1,0 +1,143 @@
+import { FC, useState, useEffect } from "react";
+import api from "../../../../utils/api";
+import { Input, Modal } from '@/components/ui';
+
+interface Event {
+    id: string;
+    name: string;
+    description: string;
+    location: string;
+    start_time: string;
+    end_time: string;
+}
+
+interface EditEventProps {
+    isOpen: boolean;
+    onClose: () => void;
+    clubId: string;
+    teamId: string;
+    event: Event | null;
+    onSuccess: () => void;
+}
+
+const EditEvent: FC<EditEventProps> = ({ isOpen, onClose, clubId, teamId, event, onSuccess }) => {
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [location, setLocation] = useState('');
+    const [startTime, setStartTime] = useState('');
+    const [endTime, setEndTime] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (event) {
+            setName(event.name || '');
+            setDescription(event.description || '');
+            setLocation(event.location || '');
+            try {
+                setStartTime(new Date(event.start_time).toISOString().slice(0,16));
+                setEndTime(new Date(event.end_time).toISOString().slice(0,16));
+            } catch {
+                setStartTime('');
+                setEndTime('');
+            }
+        }
+    }, [event]);
+
+    if (!isOpen || !event) return null;
+
+    const handleSubmit = async () => {
+        if (!name || !startTime || !endTime) {
+            setError("Please fill in all required fields (name, start time, and end time)");
+            return;
+        }
+        const startDateTime = new Date(startTime);
+        const endDateTime = new Date(endTime);
+        if (startDateTime >= endDateTime) {
+            setError("End date/time must be after start date/time");
+            return;
+        }
+        setError(null);
+        setIsSubmitting(true);
+        try {
+            await api.put(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${event.id}`, {
+                name,
+                description,
+                location,
+                start_time: startDateTime.toISOString(),
+                end_time: endDateTime.toISOString()
+            });
+            onSuccess();
+            onClose();
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                setError("Failed to update event: " + error.message);
+            } else {
+                setError("Failed to update event: Unknown error");
+            }
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleClose = () => {
+        setError(null);
+        onClose();
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={handleClose} title="Edit Event">
+            <Modal.Error error={error} />
+            <Modal.Body>
+                <div className="modal-form-section">
+                    <Input
+                        label="Event Name"
+                        id="eventName"
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        disabled={isSubmitting}
+                    />
+                    <Input
+                        label="Description"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        disabled={isSubmitting}
+                        multiline
+                        rows={3}
+                    />
+                    <Input
+                        label="Location"
+                        id="eventLocation"
+                        type="text"
+                        value={location}
+                        onChange={(e) => setLocation(e.target.value)}
+                        disabled={isSubmitting}
+                    />
+                    <Input
+                        label="Start Date & Time"
+                        id="startTime"
+                        type="datetime-local"
+                        value={startTime}
+                        onChange={(e) => setStartTime(e.target.value)}
+                        disabled={isSubmitting}
+                    />
+                    <Input
+                        label="End Date & Time"
+                        id="endTime"
+                        type="datetime-local"
+                        value={endTime}
+                        onChange={(e) => setEndTime(e.target.value)}
+                        disabled={isSubmitting}
+                    />
+                </div>
+            </Modal.Body>
+            <Modal.Actions>
+                <button onClick={handleSubmit} className="button-accept" disabled={isSubmitting}>{isSubmitting ? (<><Modal.LoadingSpinner />Saving...</>) : 'Save Changes'}</button>
+                <button onClick={handleClose} className="button-cancel" disabled={isSubmitting}>Cancel</button>
+            </Modal.Actions>
+        </Modal>
+    );
+};
+
+export default EditEvent;

--- a/Frontend/src/pages/teams/admin/events/EventRSVPList.tsx
+++ b/Frontend/src/pages/teams/admin/events/EventRSVPList.tsx
@@ -1,0 +1,126 @@
+import { FC, useState, useEffect } from "react";
+import { Table, TableColumn } from '@/components/ui';
+import Modal from '@/components/ui/Modal';
+import api from "../../../../utils/api";
+
+interface EventRSVP {
+    id: string;
+    event_id: string;
+    user_id: string;
+    response: string;
+    created_at: string;
+    updated_at: string;
+    user: {
+        id: string;
+        FirstName: string;
+        LastName: string;
+        Email: string;
+    };
+}
+
+interface RSVPCounts {
+    yes?: number;
+    no?: number;
+    maybe?: number;
+}
+
+interface EventRSVPListProps {
+    isOpen: boolean;
+    onClose: () => void;
+    eventId: string;
+    eventName: string;
+    clubId: string;
+    teamId: string;
+}
+
+const EventRSVPList: FC<EventRSVPListProps> = ({ isOpen, onClose, eventId, eventName, clubId, teamId }) => {
+    const [rsvps, setRsvps] = useState<EventRSVP[]>([]);
+    const [counts, setCounts] = useState<RSVPCounts>({});
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchRSVPs = async () => {
+        if (!isOpen || !eventId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${eventId}/rsvps`);
+            setRsvps(response.data.rsvps || []);
+            setCounts(response.data.counts || {});
+        } catch (err) {
+            console.error('Error fetching RSVPs:', err);
+            setError('Failed to load RSVPs');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchRSVPs();
+    }, [isOpen, eventId, clubId, teamId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const formatDateTime = (timestamp: string) => {
+        try {
+            const dateTime = new Date(timestamp);
+            return dateTime.toLocaleString();
+        } catch {
+            return timestamp;
+        }
+    };
+
+    const rsvpColumns: TableColumn<EventRSVP>[] = [
+        {
+            key: 'member',
+            header: 'Member',
+            render: (rsvp) => rsvp.user ? `${rsvp.user.FirstName} ${rsvp.user.LastName}`.trim() || 'Unknown' : 'Unknown'
+        },
+        {
+            key: 'response',
+            header: 'Response',
+            render: (rsvp) => (
+                <span style={{
+                    color: rsvp.response === 'yes' ? 'var(--color-primary)' :
+                           rsvp.response === 'no' ? 'var(--color-cancel)' : 'orange',
+                    fontWeight: 'bold'
+                }}>
+                    {rsvp.response === 'yes' ? 'Yes' : rsvp.response === 'no' ? 'No' : 'Maybe'}
+                </span>
+            )
+        },
+        {
+            key: 'date_responded',
+            header: 'Date Responded',
+            render: (rsvp) => formatDateTime(rsvp.updated_at)
+        }
+    ];
+
+    if (!isOpen) return null;
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={`RSVPs for ${eventName}`} maxWidth="800px">
+            <Modal.Body>
+                <div style={{ marginBottom: '20px', padding: '15px', backgroundColor: 'var(--color-background)', borderRadius: 'var(--border-radius-md)', border: '1px solid var(--color-border)' }}>
+                    <h3 style={{ margin: '0 0 10px 0', color: 'var(--color-text)' }}>Summary</h3>
+                    <div style={{ display: 'flex', gap: '20px' }}>
+                        <span style={{ color: 'var(--color-primary)', fontWeight: 'bold' }}>Yes: {counts.yes || 0}</span>
+                        <span style={{ color: 'var(--color-cancel)', fontWeight: 'bold' }}>No: {counts.no || 0}</span>
+                        <span style={{ color: 'orange', fontWeight: 'bold' }}>Maybe: {counts.maybe || 0}</span>
+                        <span style={{ color: 'var(--color-text-secondary)', fontWeight: 'bold' }}>Total: {(counts.yes || 0) + (counts.no || 0) + (counts.maybe || 0)}</span>
+                    </div>
+                </div>
+                {loading && <p>Loading RSVPs...</p>}
+                {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+                {!loading && !error && (
+                    <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+                        <Table columns={rsvpColumns} data={rsvps} keyExtractor={(rsvp) => rsvp.id} emptyMessage="No RSVPs yet for this event." />
+                    </div>
+                )}
+            </Modal.Body>
+            <Modal.Actions>
+                <button onClick={onClose} className="button-cancel">Close</button>
+            </Modal.Actions>
+        </Modal>
+    );
+};
+
+export default EventRSVPList;

--- a/Frontend/src/pages/teams/events/EventDetails.css
+++ b/Frontend/src/pages/teams/events/EventDetails.css
@@ -1,0 +1,177 @@
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.breadcrumb {
+    color: var(--color-text-secondary);
+}
+
+.breadcrumb a {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.breadcrumb a:hover {
+    text-decoration: underline;
+}
+
+.event-details-card {
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: var(--border-radius-lg);
+    padding: 30px;
+    box-shadow: var(--shadow-sm);
+}
+
+.event-details-card h1 {
+    margin: 0 0 30px 0;
+    color: var(--color-text);
+    font-size: 2.5em;
+    text-align: center;
+}
+
+.event-info {
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+}
+
+.info-section {
+    padding: 20px;
+    background: var(--color-surface);
+    border-radius: var(--border-radius-md);
+    border: 1px solid var(--color-border);
+}
+
+.info-section h3 {
+    margin: 0 0 15px 0;
+    color: var(--color-text);
+    font-size: 1.3em;
+    border-bottom: 2px solid var(--color-primary);
+    padding-bottom: 8px;
+}
+
+.schedule-details {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.schedule-item {
+    font-size: 1.1em;
+    color: var(--color-text);
+}
+
+.rsvp-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.current-rsvp {
+    padding: 15px;
+    background: var(--color-background);
+    border-radius: var(--border-radius-md);
+    border: 1px solid var(--color-border);
+}
+
+.rsvp-status {
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+.rsvp-status.yes {
+    color: var(--color-primary);
+}
+
+.rsvp-status.maybe {
+    color: orange;
+}
+
+.rsvp-status.no {
+    color: var(--color-cancel);
+}
+
+.rsvp-date {
+    color: var(--color-text-secondary);
+    font-size: 0.9em;
+    margin-top: 8px;
+}
+
+.rsvp-actions h4 {
+    margin: 0 0 10px 0;
+    color: var(--color-text);
+}
+
+.button-group {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.button-group button.active {
+    transform: scale(1.05);
+    box-shadow: 0 0 0 2px var(--color-primary);
+}
+
+.meta-info {
+    color: var(--color-text-secondary);
+    font-size: 0.95em;
+}
+
+.loading,
+.error-container {
+    text-align: center;
+    padding: 40px 20px;
+}
+
+.loading {
+    color: var(--color-text-secondary);
+    font-size: 1.2em;
+}
+
+.error-container h2 {
+    color: var(--color-cancel);
+    margin-bottom: 15px;
+}
+
+.error-container p {
+    color: var(--color-text);
+    margin-bottom: 25px;
+    font-size: 1.1em;
+}
+
+@media (max-width: 768px) {
+    .page-header {
+        flex-direction: column;
+        gap: 15px;
+        align-items: stretch;
+    }
+
+    .event-details-card {
+        padding: 20px;
+    }
+
+    .event-details-card h1 {
+        font-size: 2em;
+    }
+
+    .info-section {
+        padding: 15px;
+    }
+
+    .button-group {
+        flex-direction: column;
+    }
+}

--- a/Frontend/src/pages/teams/events/EventDetails.tsx
+++ b/Frontend/src/pages/teams/events/EventDetails.tsx
@@ -1,0 +1,172 @@
+import { FC, useState, useEffect } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import api from "../../../utils/api";
+import "./EventDetails.css";
+
+interface UserRSVP {
+    id: string;
+    event_id: string;
+    user_id: string;
+    response: string;
+    created_at: string;
+    updated_at: string;
+}
+
+interface EventDetailsData {
+    id: string;
+    name: string;
+    description: string;
+    location: string;
+    start_time: string;
+    end_time: string;
+    created_at: string;
+    created_by: string;
+    updated_at: string;
+    updated_by: string;
+    user_rsvp?: UserRSVP;
+}
+
+const TeamEventDetails: FC = () => {
+    const { clubId, teamId, eventId } = useParams<{ clubId: string; teamId: string; eventId: string }>();
+    const navigate = useNavigate();
+    const [eventData, setEventData] = useState<EventDetailsData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [rsvpLoading, setRsvpLoading] = useState(false);
+
+    const fetchEventDetails = async (abortSignal?: AbortSignal) => {
+        if (!clubId || !teamId || !eventId) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await api.get(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${eventId}`, { signal: abortSignal });
+            if (!abortSignal?.aborted) {
+                setEventData(response.data);
+            }
+        } catch (err: any) {
+            if (!abortSignal?.aborted) {
+                console.error('Error fetching event details:', err);
+                if (err?.response?.status === 404) {
+                    setError('Event not found');
+                } else if (err?.response?.status === 403) {
+                    setError("You don't have permission to view this event");
+                } else {
+                    setError('Failed to load event details');
+                }
+            }
+        } finally {
+            if (!abortSignal?.aborted) {
+                setLoading(false);
+            }
+        }
+    };
+
+    useEffect(() => {
+        const abortController = new AbortController();
+        fetchEventDetails(abortController.signal);
+        return () => abortController.abort();
+    }, [clubId, teamId, eventId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleRSVP = async (response: string) => {
+        if (!clubId || !teamId || !eventId || rsvpLoading) return;
+        setRsvpLoading(true);
+        try {
+            await api.post(`/api/v1/clubs/${clubId}/teams/${teamId}/events/${eventId}/rsvp`, { response });
+            await fetchEventDetails();
+        } catch (err) {
+            console.error('Error updating RSVP:', err);
+            alert('Failed to update RSVP. Please try again.');
+        } finally {
+            setRsvpLoading(false);
+        }
+    };
+
+    const formatDate = (timestamp: string) => {
+        try {
+            const date = new Date(timestamp);
+            return date.toLocaleDateString();
+        } catch {
+            return timestamp;
+        }
+    };
+
+    const formatTime = (timestamp: string) => {
+        try {
+            const time = new Date(timestamp);
+            return time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+        } catch {
+            return timestamp;
+        }
+    };
+
+    if (loading) {
+        return <div className="container"><div className="loading">Loading event details...</div></div>;
+    }
+    if (error) {
+        return (
+            <div className="container">
+                <div className="error-container">
+                    <h2>Error</h2>
+                    <p>{error}</p>
+                    <div className="button-group">
+                        <button onClick={() => navigate(-1)} className="button-secondary">Go Back</button>
+                        <Link to={`/clubs/${clubId}`} className="button-primary">Back to Club</Link>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+    if (!eventData) {
+        return <div className="container"><div>No event data available</div></div>;
+    }
+    const { user_rsvp } = eventData;
+    return (
+        <div className="container">
+            <div className="page-header">
+                <div className="breadcrumb">
+                    <Link to={`/clubs/${clubId}`}>Club</Link>
+                    <span> / </span>
+                    <Link to={`/clubs/${clubId}/teams/${teamId}`}>Team</Link>
+                    <span> / </span>
+                    <span>Event Details</span>
+                </div>
+                <button onClick={() => navigate(-1)} className="button-secondary">Go Back</button>
+            </div>
+            <div className="event-details-card">
+                <h1>{eventData.name}</h1>
+                {eventData.description && (
+                    <div className="info-section">
+                        <h3>Description</h3>
+                        <p className="event-description">{eventData.description}</p>
+                    </div>
+                )}
+                {eventData.location && (
+                    <div className="info-section">
+                        <h3>Location</h3>
+                        <p className="event-location">{eventData.location}</p>
+                    </div>
+                )}
+                <div className="event-info">
+                    <div className="info-section">
+                        <h3>Event Schedule</h3>
+                        <div className="schedule-details">
+                            <div className="schedule-item"><strong>Date:</strong> {formatDate(eventData.start_time)}</div>
+                            <div className="schedule-item"><strong>Start:</strong> {formatTime(eventData.start_time)}</div>
+                            <div className="schedule-item"><strong>End:</strong> {formatTime(eventData.end_time)}</div>
+                        </div>
+                    </div>
+                </div>
+                <div className="rsvp-section">
+                    <h3>Your RSVP</h3>
+                    <div className="rsvp-buttons">
+                        <button onClick={() => handleRSVP('yes')} className={user_rsvp?.response === 'yes' ? 'button-accept' : 'button'} disabled={rsvpLoading}>Yes</button>
+                        <button onClick={() => handleRSVP('maybe')} className={user_rsvp?.response === 'maybe' ? 'button-maybe' : 'button'} disabled={rsvpLoading}>Maybe</button>
+                        <button onClick={() => handleRSVP('no')} className={user_rsvp?.response === 'no' ? 'button-cancel' : 'button'} disabled={rsvpLoading}>No</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default TeamEventDetails;


### PR DESCRIPTION
## Summary
- add TeamEvent and TeamEventRSVP models and CRUD on teams
- expose /api/v1/clubs/{clubid}/teams/{teamid}/events endpoints and routes
- introduce team event pages and admin management UI

## Testing
- `go test ./...` *(fails: no output)*
- `CI=true npm test` *(fails: 1 failed, 150 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68988c015f80832897b3f12339e48247