### PR TITLE
Guard browser-only APIs for server environments

### DIFF
--- a/Frontend/src/components/CookieConsent.tsx
+++ b/Frontend/src/components/CookieConsent.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './CookieConsent.css';
+import storage from '../utils/isomorphicStorage';
 
 const COOKIE_CONSENT_KEY = 'cookie-consent';
 
@@ -8,14 +9,14 @@ const CookieConsent: React.FC = () => {
 
   useEffect(() => {
     // Check if user has already given consent
-    const consent = localStorage.getItem(COOKIE_CONSENT_KEY);
+    const consent = storage.getItem(COOKIE_CONSENT_KEY);
     if (!consent) {
       setIsVisible(true);
     }
   }, []);
 
   const handleAccept = () => {
-    localStorage.setItem(COOKIE_CONSENT_KEY, 'accepted');
+    storage.setItem(COOKIE_CONSENT_KEY, 'accepted');
     setIsVisible(false);
   };
 

--- a/Frontend/src/components/layout/GlobalSearch.tsx
+++ b/Frontend/src/components/layout/GlobalSearch.tsx
@@ -31,6 +31,7 @@ const GlobalSearch: React.FC = () => {
 
   // Close dropdown when clicking outside
   useEffect(() => {
+    if (typeof document === 'undefined') return;
     function handleClickOutside(event: MouseEvent) {
       if (searchRef.current && !searchRef.current.contains(event.target as Node)) {
         setIsOpen(false);

--- a/Frontend/src/components/layout/Header.tsx
+++ b/Frontend/src/components/layout/Header.tsx
@@ -40,6 +40,7 @@ const Header: React.FC<HeaderProps> = ({ title, isClubAdmin, clubId, showRecentC
 
   // Close dropdown when clicking outside
   useEffect(() => {
+    if (typeof document === 'undefined') return;
     function handleClickOutside(event: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsDropdownOpen(false);

--- a/Frontend/src/components/layout/NotificationDropdown.tsx
+++ b/Frontend/src/components/layout/NotificationDropdown.tsx
@@ -39,6 +39,7 @@ const NotificationDropdown: React.FC<NotificationDropdownProps> = ({
 
   // Close dropdown when clicking outside
   useEffect(() => {
+    if (typeof document === 'undefined') return;
     function handleClickOutside(event: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);

--- a/Frontend/src/components/layout/RecentClubsDropdown.tsx
+++ b/Frontend/src/components/layout/RecentClubsDropdown.tsx
@@ -17,6 +17,7 @@ const RecentClubsDropdown: React.FC = () => {
 
   // Close dropdown when clicking outside
   useEffect(() => {
+    if (typeof document === 'undefined') return;
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         setIsOpen(false);

--- a/Frontend/src/i18n/index.ts
+++ b/Frontend/src/i18n/index.ts
@@ -14,23 +14,34 @@ const resources = {
   }
 };
 
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
+if (typeof window !== 'undefined') {
+  i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+      resources,
+      fallbackLng: 'en',
+      debug: false,
+
+      detection: {
+        order: ['localStorage', 'navigator', 'htmlTag'],
+        caches: ['localStorage'],
+        lookupLocalStorage: 'i18nextLng',
+      },
+
+      interpolation: {
+        escapeValue: false,
+      },
+    });
+} else {
+  i18n.use(initReactI18next).init({
     resources,
     fallbackLng: 'en',
     debug: false,
-    
-    detection: {
-      order: ['localStorage', 'navigator', 'htmlTag'],
-      caches: ['localStorage'],
-      lookupLocalStorage: 'i18nextLng',
-    },
-
     interpolation: {
-      escapeValue: false, // not needed for react as it escapes by default
+      escapeValue: false,
     },
   });
+}
 
 export default i18n;

--- a/Frontend/src/main.tsx
+++ b/Frontend/src/main.tsx
@@ -4,6 +4,10 @@ import './index.css'
 import './i18n/index.ts'
 import App from './App.tsx'
 
-createRoot(document.getElementById('root')!).render(
-    <App />
-)
+const rootEl = typeof document !== 'undefined' ? document.getElementById('root') : null
+
+if (rootEl) {
+  createRoot(rootEl).render(
+      <App />
+  )
+}

--- a/Frontend/src/pages/auth/Login.tsx
+++ b/Frontend/src/pages/auth/Login.tsx
@@ -25,7 +25,9 @@ const Login: React.FC = () => {
       // Store redirect path for after login
       const params = new URLSearchParams(location.search);
       const redirectPath = params.get('redirect') || '/';
-      sessionStorage.setItem('auth_redirect_after_login', redirectPath);
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('auth_redirect_after_login', redirectPath);
+      }
       
       // Get the Keycloak auth URL from our backend
       const response = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/auth/keycloak/login`);
@@ -36,7 +38,9 @@ const Login: React.FC = () => {
       const data = await response.json();
       
       // Redirect to Keycloak
-      window.location.href = data.authURL;
+      if (typeof window !== 'undefined') {
+        window.location.href = data.authURL;
+      }
     } catch {
       setMessage(t('auth.keycloakError'));
     }

--- a/Frontend/src/pages/auth/MagicLinkHandler.tsx
+++ b/Frontend/src/pages/auth/MagicLinkHandler.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
 import CookieConsent from '../../components/CookieConsent';
+import storage from '../../utils/isomorphicStorage';
 
 const MagicLinkHandler: React.FC = () => {
   const [status, setStatus] = useState<'verifying' | 'success' | 'error'>('verifying');
@@ -41,9 +42,9 @@ const MagicLinkHandler: React.FC = () => {
             if (!data.profileComplete) {
               navigate('/signup');
             } else {
-              const redirectPath = localStorage.getItem('loginRedirect');
+              const redirectPath = storage.getItem('loginRedirect');
               if (redirectPath) {
-                localStorage.removeItem('loginRedirect');
+                storage.removeItem('loginRedirect');
                 navigate(redirectPath);
               } else {
                 navigate('/');

--- a/Frontend/src/pages/clubs/JoinClub.tsx
+++ b/Frontend/src/pages/clubs/JoinClub.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../hooks/useAuth';
 import api from '../../utils/api';
 import ClubNotFound from './ClubNotFound';
 import { removeRecentClub } from '../../utils/recentClubs';
+import storage from '../../utils/isomorphicStorage';
 
 interface Club {
   id: string;
@@ -49,10 +50,14 @@ const JoinClub: React.FC = () => {
 
   useEffect(() => {
     if (!isAuthenticated) {
-      // Store current URL for redirect after login
-      localStorage.setItem('loginRedirect', window.location.pathname);
-      // Redirect to login with return URL
-      navigate(`/login?redirect=${encodeURIComponent(window.location.pathname)}`);
+      if (typeof window !== 'undefined') {
+        // Store current URL for redirect after login
+        storage.setItem('loginRedirect', window.location.pathname);
+        // Redirect to login with return URL
+        navigate(`/login?redirect=${encodeURIComponent(window.location.pathname)}`);
+      } else {
+        navigate('/login');
+      }
       return;
     }
 

--- a/Frontend/src/pages/clubs/admin/AdminClubDetails.tsx
+++ b/Frontend/src/pages/clubs/admin/AdminClubDetails.tsx
@@ -354,7 +354,11 @@ const AdminClubDetails = () => {
                                                                     style={{ display: 'none' }}
                                                                 />
                                                                 <button
-                                                                    onClick={() => document.getElementById('logo-upload')?.click()}
+                                                                    onClick={() => {
+                                                                        if (typeof document !== 'undefined') {
+                                                                            document.getElementById('logo-upload')?.click();
+                                                                        }
+                                                                    }}
                                                                     className="logo-change-btn"
                                                                     disabled={logoUploading}
                                                                 >
@@ -374,7 +378,11 @@ const AdminClubDetails = () => {
                                                     <div className="club-logo-placeholder">
                                                         <div 
                                                             className="logo-placeholder"
-                                                            onClick={!club.deleted ? () => document.getElementById('logo-upload')?.click() : undefined}
+                                                            onClick={!club.deleted ? () => {
+                                                                if (typeof document !== 'undefined') {
+                                                                    document.getElementById('logo-upload')?.click();
+                                                                }
+                                                            } : undefined}
                                                         >
                                                             {!club.deleted ? 'Click to upload logo' : 'No logo'}
                                                         </div>

--- a/Frontend/src/pages/clubs/admin/events/AdminEventDetails.tsx
+++ b/Frontend/src/pages/clubs/admin/events/AdminEventDetails.tsx
@@ -131,9 +131,9 @@ const AdminEventDetails: FC = () => {
     const handleDeleteEvent = async () => {
         if (!clubId || !eventId) return;
         
-        const confirmDelete = window.confirm(
-            "Are you sure you want to delete this event? This action cannot be undone."
-        );
+        const confirmDelete = typeof window !== 'undefined'
+            ? window.confirm("Are you sure you want to delete this event? This action cannot be undone.")
+            : false;
         
         if (!confirmDelete) return;
         

--- a/Frontend/src/pages/clubs/admin/members/AdminClubMemberList.tsx
+++ b/Frontend/src/pages/clubs/admin/members/AdminClubMemberList.tsx
@@ -91,7 +91,8 @@ const AdminClubMemberList = ({ openJoinRequests = false }: AdminClubMemberListPr
     const handleShowInviteLink = async () => {
         try {
             const response = await api.get(`/api/v1/clubs/${id}/inviteLink`);
-            const fullLink = `${window.location.origin}${response.data.inviteLink}`;
+            const origin = typeof window !== 'undefined' ? window.location.origin : '';
+            const fullLink = `${origin}${response.data.inviteLink}`;
             setInviteLink(fullLink);
             setShowInviteLink(true);
         } catch (error) {

--- a/Frontend/src/pages/profile/ProfileSessions.tsx
+++ b/Frontend/src/pages/profile/ProfileSessions.tsx
@@ -4,6 +4,7 @@ import ProfileSidebar from "./ProfileSidebar";
 import { useAuth } from '../../hooks/useAuth';
 import { Table, TableColumn } from '@/components/ui';
 import './Profile.css';
+import storage from '../../utils/isomorphicStorage';
 
 interface Session {
   id: string;
@@ -22,7 +23,7 @@ const ProfileSessions = () => {
   const fetchSessions = useCallback(async () => {
     try {
       setIsLoading(true);
-      const refreshToken = localStorage.getItem('refresh_token');
+      const refreshToken = storage.getItem('refresh_token');
       const headers: Record<string, string> = {};
       if (refreshToken) {
         headers['X-Refresh-Token'] = refreshToken;

--- a/Frontend/src/utils/isomorphicStorage.ts
+++ b/Frontend/src/utils/isomorphicStorage.ts
@@ -1,0 +1,18 @@
+const isBrowser = typeof window !== 'undefined';
+
+export const getItem = (key: string): string | null => {
+  if (!isBrowser) return null;
+  return window.localStorage.getItem(key);
+};
+
+export const setItem = (key: string, value: string): void => {
+  if (!isBrowser) return;
+  window.localStorage.setItem(key, value);
+};
+
+export const removeItem = (key: string): void => {
+  if (!isBrowser) return;
+  window.localStorage.removeItem(key);
+};
+
+export default { getItem, setItem, removeItem };

--- a/Frontend/src/utils/recentClubs.ts
+++ b/Frontend/src/utils/recentClubs.ts
@@ -2,6 +2,8 @@
  * Utility functions for tracking and managing recently visited clubs
  */
 
+import storage from './isomorphicStorage';
+
 export interface RecentClub {
   id: string;
   name: string;
@@ -16,7 +18,7 @@ const MAX_RECENT_CLUBS = 5;
  */
 export const getRecentClubs = (): RecentClub[] => {
   try {
-    const stored = localStorage.getItem(RECENT_CLUBS_KEY);
+    const stored = storage.getItem(RECENT_CLUBS_KEY);
     if (!stored) return [];
     
     const clubs = JSON.parse(stored) as RecentClub[];
@@ -42,7 +44,7 @@ export const addRecentClub = (clubId: string, clubName: string): void => {
       ...filtered
     ].slice(0, MAX_RECENT_CLUBS);
     
-    localStorage.setItem(RECENT_CLUBS_KEY, JSON.stringify(updated));
+    storage.setItem(RECENT_CLUBS_KEY, JSON.stringify(updated));
   } catch (error) {
     console.error('Error saving recent club:', error);
   }
@@ -52,7 +54,7 @@ export const removeRecentClub = (clubId: string): void => {
   try {
     const existing = getRecentClubs();
     const filtered = existing.filter(club => club.id !== clubId);
-    localStorage.setItem(RECENT_CLUBS_KEY, JSON.stringify(filtered));
+    storage.setItem(RECENT_CLUBS_KEY, JSON.stringify(filtered));
   } catch (error) {
     console.error('Error removing recent club:', error);
   }
@@ -60,7 +62,7 @@ export const removeRecentClub = (clubId: string): void => {
 
 export const clearRecentClubs = (): void => {
   try {
-    localStorage.removeItem(RECENT_CLUBS_KEY);
+    storage.removeItem(RECENT_CLUBS_KEY);
   } catch (error) {
     console.error('Error clearing recent clubs:', error);
   }


### PR DESCRIPTION
## Summary
- add isomorphic localStorage wrapper
- guard window access in auth and keycloak flows
- protect components against missing document in server environments

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad87fd28088328a0d6e00c5fecc12a