### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,4 +1,6 @@
 name: Frontend Tests and Linting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/NLstn/clubs/security/code-scanning/3](https://github.com/NLstn/clubs/security/code-scanning/3)

To implement the fix, add a `permissions` block setting the minimal required permissions at the workflow or job level. Since the job only checks out code, sets up Node, installs dependencies, lints, builds, and tests, the only required permission is `contents: read`. This should be set at the top level of the workflow, beneath the workflow name and before the `on:` block, or within the job definition. To follow best practice and cover all jobs (both now and in the future), the best solution is to add it at the root.  
**Edit details**:  
- In `.github/workflows/frontend.yml`, after the `name: Frontend Tests and Linting` line (line 1), insert:
  ```
  permissions:
    contents: read
  ```
- No imports or additional configuration is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
